### PR TITLE
Add 4.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.0.*",
+        "illuminate/support": "~4.0",
         "bugsnag/bugsnag": ">=2.0.3"
     },
     "autoload": {


### PR DESCRIPTION
Bugsnag for Laravel works out-of-the-box in Laravel 4.1! This PR will allow installation in 4.1 applications.
