### PR TITLE
Prevents FatalErrorException being captured twice

### DIFF
--- a/src/Bugsnag/BugsnagLaravel/BugsnagLaravelServiceProvider.php
+++ b/src/Bugsnag/BugsnagLaravel/BugsnagLaravelServiceProvider.php
@@ -24,8 +24,9 @@ class BugsnagLaravelServiceProvider extends ServiceProvider
 
         // Register for exception handling
         $app->error(function (\Exception $exception) use ($app) {
-            $reflect = new \ReflectionClass($exception);
-            if ('FatalErrorException' !== $reflect->getShortName()) {
+            if ('Symfony\Component\Debug\Exception\FatalErrorException'
+                !== get_class($exception)
+            ) {
                 $app['bugsnag']->notifyException($exception);
             }
         });


### PR DESCRIPTION
See #31

When the stack of handlers is processed (in reverse order) a `FatalErrorException` is passed onto the **second** closure (top of stack) and it will be run as the type hint on `$exception` is `FatalErrorException`. As it returns no response/output, the stack processing continues and it's also run on the **first** closure. As `FatalErrorException` is a sub-type `Exception` it also gets run on that as well.

I will link a pull request for the fix that I have made. I have tested it locally. Let me know if you need any clarification on the above.
