### PR TITLE
Check for auth IOC binding before automatically setting user id

### DIFF
--- a/src/Bugsnag/BugsnagLaravel/BugsnagLaravelServiceProvider.php
+++ b/src/Bugsnag/BugsnagLaravel/BugsnagLaravelServiceProvider.php
@@ -80,7 +80,7 @@ class BugsnagLaravelServiceProvider extends ServiceProvider
             }
 
             // Check if someone is logged in.
-            if ($app['auth']->check()) {
+            if ($app->bound('auth') && $app['auth']->check()) {
                 // User is logged in.
                 $user = $app['auth']->user();
 


### PR DESCRIPTION
The Exception handler fails if Laravel's default auth service provider has been removed. This PR checks for the auth binding before trying to call the check() method.