### PR TITLE
Try/catch for missing/nonstandard auth service

### DIFF
--- a/src/Bugsnag/BugsnagLaravel/BugsnagLaravelServiceProvider.php
+++ b/src/Bugsnag/BugsnagLaravel/BugsnagLaravelServiceProvider.php
@@ -80,12 +80,16 @@ class BugsnagLaravelServiceProvider extends ServiceProvider
             }
 
             // Check if someone is logged in.
-            if ($app['auth']->check()) {
-                // User is logged in.
-                $user = $app['auth']->user();
-
-                // If these attributes are available: pass them on.
-                $client->setUser(array('id' => $user->getAuthIdentifier()));
+            try {
+                if ($app['auth']->check()) {
+                    // User is logged in.
+                    $user = $app['auth']->user();
+    
+                    // If these attributes are available: pass them on.
+                    $client->setUser(array('id' => $user->getAuthIdentifier()));
+                }
+            } catch (\Exception $e) {
+                // Do nothing.
             }
 
             return $client;


### PR DESCRIPTION
Degrades gracefully in situations where the standard Laravel auth service provider has been swapped out or removed. Refers to https://github.com/bugsnag/bugsnag-laravel/pull/43#issuecomment-83157458.