### PR TITLE
Refactor BugsnagExceptionHandler

### DIFF
--- a/src/Bugsnag/BugsnagLaravel/BugsnagExceptionTrait.php
+++ b/src/Bugsnag/BugsnagLaravel/BugsnagExceptionTrait.php
@@ -1,25 +1,6 @@
 <?php namespace Bugsnag\BugsnagLaravel;
 
-use Exception;
-use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
-
-class BugsnagExceptionHandler extends ExceptionHandler {
-
-    /**
-     * Report or log an exception.
-     *
-     * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
-     *
-     * @param  \Exception  $e
-     * @return void
-     */
-    public function report(Exception $e)
-    {
-        $this->reportToBugsnag($e);
-
-        return parent::report($e);
-    }
-
+trait BugsnagExceptionTrait {
     /**
      * Report exception to Bugsnag.
      *


### PR DESCRIPTION
* Check if `BugsnagServiceProvider` is actually loaded before trying to use it by checking for
`App::bound('bugsnag')`. Useful for environment where you don't want to configure bugsnag and leave the config as default (without any API key).
* Add `BugsnagExceptionTrait` (require PHP 5.4.0 but would be extremely useful for Laravel 5.

Signed-off-by: crynobone <crynobone@gmail.com>