### PR TITLE
verifying existence bugsnag in service file - issue #42

### DIFF
--- a/src/Bugsnag/BugsnagLaravel/BugsnagLaravelServiceProvider.php
+++ b/src/Bugsnag/BugsnagLaravel/BugsnagLaravelServiceProvider.php
@@ -49,7 +49,10 @@ class BugsnagLaravelServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('bugsnag', function ($app) {
-            $config = $app['config']['bugsnag'] ?: $app['config']['bugsnag::config'];
+            $config = isset($app['config']['services']['bugsnag']) ? $app['config']['services']['bugsnag'] : null;
+            if (is_null($config)) {
+                $config = $app['config']['bugsnag'] ?: $app['config']['bugsnag::config'];
+            }
 
             $client = new \Bugsnag_Client($config['api_key']);
             $client->setStripPath(base_path());


### PR DESCRIPTION
This change verifies if there’s an option for bugsnag in
`config/services.php` file. if so, it gets `$config` from there.

Therefore, it’s possible to retrieve API key from that file versus
creating a new `bugsnag.php` file.

This closes #42