### PR TITLE
Declare Illuminate\Support\ServiceProvider class

### DIFF
--- a/src/Bugsnag/BugsnagLaravel/BugsnagLumenServiceProvider.php
+++ b/src/Bugsnag/BugsnagLaravel/BugsnagLumenServiceProvider.php
@@ -1,5 +1,7 @@
 <?php namespace Bugsnag\BugsnagLaravel;
 
+use Illuminate\Support\ServiceProvider;
+
 class BugsnagLumenServiceProvider extends ServiceProvider
 {
     /**


### PR DESCRIPTION
This adds 'use Illuminate\Support\ServiceProvider;' to BugsnagLumenServiceProvider so it
won't throw _Fatal error: Class 'Bugsnag\BugsnagLaravel\ServiceProvider' not found_ on instantiation.  