### PR TITLE
Fix broken index in Config array.

### DIFF
--- a/src/Bugsnag/BugsnagLaravel/BugsnagLaravelServiceProvider.php
+++ b/src/Bugsnag/BugsnagLaravel/BugsnagLaravelServiceProvider.php
@@ -54,7 +54,7 @@ class BugsnagLaravelServiceProvider extends ServiceProvider
                 $config = $app['config']['bugsnag'] ?: $app['config']['bugsnag::config'];
             }
 
-            $client = new \Bugsnag_Client($config['api_key']);
+            $client = new \Bugsnag_Client($config['key']);
             $client->setStripPath(base_path());
             $client->setProjectRoot(app_path());
             $client->setAutoNotify(false);


### PR DESCRIPTION
Was receiving index error on Laravel 4.2. The api key in the config array had a key of 'key', not 'api_key'. - How's that for a tongue twister.

I'm surprised nobody else was receiving this issue. Unless there's something glaringly obvious I've skipped over.