### PR TITLE
autoNotify implementation (validate)

### DIFF
--- a/src/Bugsnag/BugsnagLaravel/BugsnagLaravelServiceProvider.php
+++ b/src/Bugsnag/BugsnagLaravel/BugsnagLaravelServiceProvider.php
@@ -25,19 +25,22 @@ class BugsnagLaravelServiceProvider extends ServiceProvider
 
             $this->package('bugsnag/bugsnag-laravel', 'bugsnag');
 
-            // Register for exception handling
-            $app->error(function (\Exception $exception) use ($app) {
-                if ('Symfony\Component\Debug\Exception\FatalErrorException'
-                    !== get_class($exception)
-                ) {
-                    $app['bugsnag']->notifyException($exception, null, "error");
-                }
-            });
+            if (\Config::get('bugsnag::autoNotify')) {
+                // Register for exception handling
+                $app->error(function (\Exception $exception) use ($app) {
+                    if ('Symfony\Component\Debug\Exception\FatalErrorException'
+                        !== get_class($exception)
+                    ) {
+                        $app['bugsnag']->notifyException($exception, null, "error");
+                    }
+                });
 
-            // Register for fatal error handling
-            $app->fatal(function ($exception) use ($app) {
-                $app['bugsnag']->notifyException($exception, null, "error");
-            });
+                // Register for fatal error handling
+                $app->fatal(function ($exception) use ($app) {
+                    $app['bugsnag']->notifyException($exception, null, "error");
+                });  
+            }
+            
         } else {
           $this->publishes(array(
               __DIR__.'/config.php' => config_path('bugsnag.php'),

--- a/src/Bugsnag/BugsnagLaravel/config.php
+++ b/src/Bugsnag/BugsnagLaravel/config.php
@@ -72,6 +72,18 @@ return array(
 	|     )
 	|
 	*/
-	'proxy' => null
+	'proxy' => null,
+
+	/*
+	|--------------------------------------------------------------------------
+	| Auto Notification
+	|--------------------------------------------------------------------------
+	|
+	| Set what server the Bugsnag notifier should automatically send errors. 
+	| By default, this is set to true, but you may wish to disable it if you
+	| are manually sending the notification from a custom error handler.
+	|
+	*/
+	'autoNotify' => true
 
 );

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -72,6 +72,18 @@ return array(
 	|     )
 	|
 	*/
-	'proxy' => null
+	'proxy' => null,
+
+	/*
+	|--------------------------------------------------------------------------
+	| Auto Notification
+	|--------------------------------------------------------------------------
+	|
+	| Set what server the Bugsnag notifier should automatically send errors. 
+	| By default, this is set to true, but you may wish to disable it if you
+	| are manually sending the notification from a custom error handler.
+	|
+	*/
+	'autoNotify' => true
 
 );


### PR DESCRIPTION
This adds an autoNotify field to both config files, defaulting to true, and a conditional wrapper around the two error registrations in the Service Provider:
```
if (\Config::get('bugsnag::autoNotify')) { ... }
```
This seems to resolve the issue for Laravel 4 releases (although it is untested). I have not tested in a Laravel 5 or Lumen environment.