### PR TITLE
remove repetitive code in exception handler

### DIFF
--- a/src/Bugsnag/BugsnagLaravel/BugsnagExceptionHandler.php
+++ b/src/Bugsnag/BugsnagLaravel/BugsnagExceptionHandler.php
@@ -14,15 +14,7 @@ class BugsnagExceptionHandler extends ExceptionHandler {
      */
     public function report(Exception $e)
     {
-        foreach ($this->dontReport as $type) {
-            if ($e instanceof $type) {
-                return parent::report($e);
-            }
-        }
-
-        $bugsnag = app('bugsnag');
-
-        if ($bugsnag) {
+        if ($this->shouldReport($e) AND $bugsnag = app('bugsnag')) {
             $bugsnag->notifyException($e, null, "error");
         }
 


### PR DESCRIPTION
- the foreach loop is doing exactly the same thing the `parent::report($e)` does, so there's no reason to duplicate the code.
- the parent class provides some nice helper methods called `shouldReport()` and `shouldntReport()`, which handle the same logic as your foreach loop