### PR TITLE
update `config.php` to utilize environment variables

### DIFF
--- a/src/Bugsnag/BugsnagLaravel/config.php
+++ b/src/Bugsnag/BugsnagLaravel/config.php
@@ -1,6 +1,6 @@
 <?php
 
-return array(
+return [
 
 	/*
 	|--------------------------------------------------------------------------
@@ -25,7 +25,7 @@ return array(
 	| Example: array('development', 'production')
 	|
 	*/
-	'notify_release_stages' => null,
+	'notify_release_stages' => env('BUGSNAG_NOTIFY_RELEASE_STAGES', null),
 
 	/*
 	|--------------------------------------------------------------------------
@@ -37,7 +37,7 @@ return array(
 	| this should be the URL to your Bugsnag instance.
 	|
 	*/
-	'endpoint' => null,
+	'endpoint' => env('BUGSNAG_ENDPOINT', null),
 
 	/*
 	|--------------------------------------------------------------------------
@@ -49,7 +49,7 @@ return array(
 	| contain these strings will be filtered.
 	|
 	*/
-	'filters' => array('password'),
+	'filters' => env('BUGSNAG_FILTERS', ['password']),
 
 	/*
 	|--------------------------------------------------------------------------
@@ -72,6 +72,6 @@ return array(
 	|     )
 	|
 	*/
-	'proxy' => null
+	'proxy' => env('BUGSNAG_PROXY', null)
 
-);
+];


### PR DESCRIPTION
assets are typically overwritten every time the package is updated, so users should have an alternative way to set their bugsnag configuration that prevents having to redo it on updates.  this update allows users to set configuration with their environment variables, but falls back on the sensible defaults. this change is non-breaking.

also use short array syntax