### PR TITLE
Only use Bugsnag when it is set in the Container

### DIFF
--- a/src/Bugsnag/BugsnagLaravel/BugsnagExceptionHandler.php
+++ b/src/Bugsnag/BugsnagLaravel/BugsnagExceptionHandler.php
@@ -20,10 +20,8 @@ class BugsnagExceptionHandler extends ExceptionHandler {
             }
         }
 
-        $bugsnag = app('bugsnag');
-
-        if ($bugsnag) {
-            $bugsnag->notifyException($e, null, "error");
+        if (app()->bound('bugsnag')) {
+            app('bugsnag')->notifyException($e, null, "error");
         }
 
         return parent::report($e);


### PR DESCRIPTION
In some cases, exceptions can be thrown before Bugsnag is even registered with the IoC container. In these cases, the app will run into a fatal error when trying to use Bugsnag to notify it for errors. See #41 and #53. I've run into this a couple of times myself.

It's better to first check if the library is already registered with the container before trying to instantiate it.