### PR TITLE
Default to empty when no key set

### DIFF
--- a/src/Bugsnag/BugsnagLaravel/config.php
+++ b/src/Bugsnag/BugsnagLaravel/config.php
@@ -13,7 +13,7 @@ return array(
 	| which should receive your application's uncaught exceptions.
 	|
 	*/
-	'api_key' => env('BUGSNAG_API_KEY'),
+	'api_key' => env('BUGSNAG_API_KEY', ''),
 
 	/*
 	|--------------------------------------------------------------------------


### PR DESCRIPTION
Users should not be required to provide a key in every environment if bugsnag is not being used there. This change sets a default 'empty' key, though I'd assume in addition we'd need to prevent triggering an upload. /cc @snmaynard 

Fixes #65