### PR TITLE
Let Laravel decide whether to report or not

### DIFF
--- a/src/Bugsnag/BugsnagLaravel/BugsnagExceptionHandler.php
+++ b/src/Bugsnag/BugsnagLaravel/BugsnagExceptionHandler.php
@@ -14,13 +14,7 @@ class BugsnagExceptionHandler extends ExceptionHandler {
      */
     public function report(Exception $e)
     {
-        foreach ($this->dontReport as $type) {
-            if ($e instanceof $type) {
-                return parent::report($e);
-            }
-        }
-
-        if (app()->bound('bugsnag')) {
+        if ($this->shouldReport($e) && app()->bound('bugsnag')) {
             app('bugsnag')->notifyException($e, null, "error");
         }
 


### PR DESCRIPTION
In Laravel 5.2, `Illuminate\Foundation\Exceptions\Handler::shouldntReport()` [was modified](https://github.com/laravel/framework/commit/87943fd0b3355af5d5d813ddfec01e05c783bd4d) to never report `Illuminate\Http\Exception\HttpResponseException` exceptions. This updated logic was never captured in the `BugsnagExceptionHandler`, so in a Laravel 5.2 application, all `HttpResponseException`s are reported by default when they shouldn't be.

It makes sense to just use `$this->shouldReport($e)` to determine if the exception should be reported - that way no logic is duplicated, and if `shouldReport()` is modified again in the future, there will be no need to update this package.

The `shouldReport()` method has been present since 5.0 so this change is compatible with 5.0-5.2.