### PR TITLE
Config updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,14 +212,7 @@ populated in `config.php` from your `.env` file:
 
 - `BUGSNAG_API_KEY`: Your API key. You can find your API key on your Bugsnag
   dashboard.
-- `BUGSNAG_NOTIFY_RELEASE_STAGES`: Set which release stages should send
-  notifications to Bugsnag.
-- `BUGSNAG_ENDPOINT`: Set what server to which the Bugsnag notifier should send
-  errors. The default is https://notify.bugsnag.com, but for Bugsnag Enterprise
-  the endpoint should be the URL of your Bugsnag instance.
-- `BUGSNAG_FILTERS`: Set which keys are filtered from metadata is sent to
-  Bugsnag.
-- `BUGSNAG_PROXY`: Set the configuration options for your server if it is behind
+- `BUGSNAG_BUGSNAG_PROXY_HOST`, `BUGSNAG_PROXY_PORT`, `BUGSNAG_PROXY_USER` and `BUGSNAG_PROXY_PASSWORD`: Set the configuration options for your server if it is behind
   a proxy server. Additional details are available in the
   [sample configuration](src/Bugsnag/BugsnagLaravel/config.php#L56).
 

--- a/src/Bugsnag/BugsnagLaravel/config.php
+++ b/src/Bugsnag/BugsnagLaravel/config.php
@@ -25,7 +25,7 @@ return array(
 	| Example: array('development', 'production')
 	|
 	*/
-	'notify_release_stages' => env('BUGSNAG_NOTIFY_RELEASE_STAGES', null),
+	'notify_release_stages' => array(),
 
 	/*
 	|--------------------------------------------------------------------------
@@ -37,7 +37,7 @@ return array(
 	| this should be the URL to your Bugsnag instance.
 	|
 	*/
-	'endpoint' => env('BUGSNAG_ENDPOINT', null),
+	'endpoint' => null,
 
 	/*
 	|--------------------------------------------------------------------------
@@ -49,7 +49,7 @@ return array(
 	| contain these strings will be filtered.
 	|
 	*/
-	'filters' => env('BUGSNAG_FILTERS', array('password')),
+	'filters' => array('password'),
 
 	/*
 	|--------------------------------------------------------------------------
@@ -72,6 +72,11 @@ return array(
 	|     )
 	|
 	*/
-	'proxy' => env('BUGSNAG_PROXY', null)
+	'proxy' => array(
+		'host' => env('BUGSNAG_PROXY_HOST'),
+		'port' => env('BUGSNAG_PROXY_PORT'),
+		'user' => env('BUGSNAG_PROXY_USER'),
+		'password' => env('BUGSNAG_PROXY_PASSWORD'),
+	),
 
 );

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -25,7 +25,7 @@ return array(
 	| Example: array('development', 'production')
 	|
 	*/
-	'notify_release_stages' => null,
+	'notify_release_stages' => array(),
 
 	/*
 	|--------------------------------------------------------------------------
@@ -72,6 +72,11 @@ return array(
 	|     )
 	|
 	*/
-	'proxy' => null
+	'proxy' => array (
+		'host' => null,
+		'port' => null,
+		'user' => null,
+		'password' => null,
+	)
 
 );


### PR DESCRIPTION
- The `vlucas/phpdotenv` library that is used to convert the values provided in Laravel 5's `.env` file to environment variables (and environment variables in general I think) doesn't support arrays, so before this change it wasn't  actually possible to set a valid value for the `BUGSNAG_NOTIFY_RELEASE_STAGES`, `BUGSNAG_ENDPOINT`, `BUGSNAG_FILTERS` and `BUGSNAG_PROXY` environment variables, making them pointless.
- More generally, the config values of `notify_release_stages`, `endpoint`, and `filters` aren't actually environment specific and don't contain sensitive data, so there is actually no need for them to retrieve their values from environment variables.

Technically, this commit breaks backwards compatibility for Laravel 5 applications are relying on the `BUGSNAG_NOTIFY_RELEASE_STAGES`, `BUGSNAG_ENDPOINT`, `BUGSNAG_FILTERS`. However, given these values never worked in the first place I would argue that this change should be seen as more of a bugfix than a breaking change.