### PR TITLE
Fixed version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.*|5.*",
-        "bugsnag/bugsnag": ">=2.5.0"
+        "bugsnag/bugsnag": "^2.5"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
It's important we don't accidentally allow 3.x to be installed.