### PR TITLE
Flush errors after running each queue job

### DIFF
--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -30,6 +30,19 @@ class BugsnagServiceProvider extends ServiceProvider
         }
 
         $this->mergeConfigFrom($source, 'bugsnag');
+
+        $callback = function () {
+            $this->app['bugsnag']->flush();
+        };
+
+        $this->app['queue']->after($callback);
+        $this->app['queue']->stopping($callback);
+
+        if (method_exists($this->app['queue'], 'exceptionOccurred')) {
+            $this->app['queue']->exceptionOccurred($callback);
+        } else {
+            $this->app['queue']->looping($callback);
+        }
     }
 
     /**


### PR DESCRIPTION
Now that the batch event setting is independent of weather we're inside a request or not, we can flush the errors after each queue job we process.