### PR TITLE
Fix LaravelLogger IoC alias typo

### DIFF
--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -122,7 +122,7 @@ class BugsnagServiceProvider extends ServiceProvider
         });
 
         $this->app->alias('bugsnag', Client::class);
-        $this->app->alias('bugsnag.logger', LaraveLogger::class);
+        $this->app->alias('bugsnag.logger', LaravelLogger::class);
         $this->app->alias('bugsnag.multi', MultiLogger::class);
     }
 


### PR DESCRIPTION
I noticed this small typo in the IoC alias of the LaraveLogger. It didn't cause any fatal errors, though, it just got highlighted in my IDE.