### PR TITLE
Bumped branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.1-dev"
+            "dev-master": "2.2-dev"
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
This can be merged once we're sure we're heading for a 2.2.0 release next, and not a 2.1.1.