### PR TITLE
Ensure compatibility with all laravel versions

### DIFF
--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -102,7 +102,9 @@ class BugsnagServiceProvider extends ServiceProvider
         }
 
         if (method_exists($queue, 'before')) {
-            $queue->before($callback);
+            $queue->before(function () {
+                $this->app->bugsnag->clearBreadcrumbs();
+            });
         } else {
             $queue->looping(function () {
                 $this->app->bugsnag->clearBreadcrumbs();

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -88,7 +88,10 @@ class BugsnagServiceProvider extends ServiceProvider
             $this->app->bugsnag->flush();
         };
 
-        $queue->before($callback);
+        if (method_exists($queue, 'before')) {
+            $queue->before($callback);
+        }
+
         $queue->after($callback);
         $queue->stopping($callback);
 
@@ -98,9 +101,13 @@ class BugsnagServiceProvider extends ServiceProvider
             $queue->looping($callback);
         }
 
-        $queue->before(function () {
-            $this->app->bugsnag->clearBreadcrumbs();
-        });
+        if (method_exists($queue, 'before')) {
+            $queue->before($callback);
+        } else {
+            $queue->looping(function () {
+                $this->app->bugsnag->clearBreadcrumbs();
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
Laravel 5.1 does not have a `before` queue job processing event nor does it have `exceptionOccurred`. Laravel 5.3 has a `looping` method, but it does nothing.