### PR TITLE
Major simplifications with queue handling

### DIFF
--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -85,32 +85,10 @@ class BugsnagServiceProvider extends ServiceProvider
      */
     protected function setupQueue(QueueManager $queue)
     {
-        $callback = function () {
+        $queue->looping(function () {
             $this->app->bugsnag->flush();
-        };
-
-        if (method_exists($queue, 'before')) {
-            $queue->before($callback);
-        }
-
-        $queue->after($callback);
-        $queue->stopping($callback);
-
-        if (method_exists($queue, 'exceptionOccurred')) {
-            $queue->exceptionOccurred($callback);
-        } else {
-            $queue->looping($callback);
-        }
-
-        if (method_exists($queue, 'before')) {
-            $queue->before(function () {
-                $this->app->bugsnag->clearBreadcrumbs();
-            });
-        } else {
-            $queue->looping(function () {
-                $this->app->bugsnag->clearBreadcrumbs();
-            });
-        }
+            $this->app->bugsnag->clearBreadcrumbs();
+        });
     }
 
     /**


### PR DESCRIPTION
As long as we're flushing and clearing between jobs on the daemon, that's good enough. We don't need to care otherwise since the shutdown function will take care of it just like for http requests.