### PR TITLE
Add api version to bugsnag

### DIFF
--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -4,6 +4,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | User defined application version
+    |--------------------------------------------------------------------------
+    |
+    | Sets the user provided application version which will be used by bugsnag.
+    |
+    | This can be overridden by setting the key in config/app.php instead.
+    |
+    */
+
+    'version' => '0.0.0',
+
+    /*
+    |--------------------------------------------------------------------------
     | API Key
     |--------------------------------------------------------------------------
     |

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -118,9 +118,9 @@ class BugsnagServiceProvider extends ServiceProvider
             $client->setReleaseStage($app->environment());
             $client->setAppType($app->runningInConsole() ? 'Console' : 'HTTP');
 
-            if($app['config']->has('app.version')) {
+            if ($app['config']->has('app.version')) {
                 $client->setAppVersion($app['config']['app.version']);
-            } else if(isset($config['version'])) {
+            } elseif(isset($config['version'])) {
                 $client->setAppVersion($config['version']);
             }
 

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -118,10 +118,10 @@ class BugsnagServiceProvider extends ServiceProvider
             $client->setReleaseStage($app->environment());
             $client->setAppType($app->runningInConsole() ? 'Console' : 'HTTP');
 
-            if(! $app['config']->has('app.version') && isset($config['version'])) {
-                $client->setAppVersion($app['version']);
-            } else {
+            if($app['config']->has('app.version')) {
                 $client->setAppVersion($app['config']['app.version']);
+            } else if(isset($config['version'])) {
+                $client->setAppVersion($config['version']);
             }
 
             $client->setNotifier([

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -118,6 +118,12 @@ class BugsnagServiceProvider extends ServiceProvider
             $client->setReleaseStage($app->environment());
             $client->setAppType($app->runningInConsole() ? 'Console' : 'HTTP');
 
+            if(! $app['config']->has('app.version') && isset($config['version'])) {
+                $client->setAppVersion($app['version']);
+            } else {
+                $client->setAppVersion($app['config']['app.version']);
+            }
+
             $client->setNotifier([
                 'name' => 'Bugsnag Laravel',
                 'version' => static::VERSION,

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -120,7 +120,7 @@ class BugsnagServiceProvider extends ServiceProvider
 
             if ($app['config']->has('app.version')) {
                 $client->setAppVersion($app['config']['app.version']);
-            } elseif(isset($config['version'])) {
+            } elseif (isset($config['version'])) {
                 $client->setAppVersion($config['version']);
             }
 


### PR DESCRIPTION
As a developer am i little annoyed of having to set `app('bugsnag')->setAppVersion()` everytime within my boot method of one of my providers just to reference a configuration item within my app.php file where i can increment the version number on deployments. 

Not sure if this should be moved up in the boot method of the provider instead tho.

 Also allow the configuration key to be overridden by setting the same key inside config/app.php
