### PR TITLE
Only log query events

### DIFF
--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -110,7 +110,7 @@ return [
     |
     */
 
-    'bindings' => env('BUGSNAG_BINDINGS', false),
+    'bindings' => env('BUGSNAG_QUERY_BINDINGS', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -90,15 +90,15 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Events
+    | Query
     |--------------------------------------------------------------------------
     |
-    | Enable this if you'd like us to automatically record all fired events as
-    | breadcrumbs. This includes both framework and user dispatched events.
+    | Enable this if you'd like us to automatically record all queries executed
+    | as breadcrumbs.
     |
     */
 
-    'events' => env('BUGSNAG_EVENTS', true),
+    'query' => env('BUGSNAG_QUERY', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -98,7 +98,19 @@ return [
     |
     */
 
-    'query' => env('BUGSNAG_QUERY', false),
+    'query' => env('BUGSNAG_QUERY', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Bindings
+    |--------------------------------------------------------------------------
+    |
+    | Enable this if you'd like us to include the query bindings in our query
+    | breadcrumbs.
+    |
+    */
+
+    'bindings' => env('BUGSNAG_BINDINGS', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/example/laravel/config/bugsnag.php
+++ b/example/laravel/config/bugsnag.php
@@ -110,7 +110,7 @@ return [
     |
     */
 
-    'bindings' => env('BUGSNAG_BINDINGS', false),
+    'bindings' => env('BUGSNAG_QUERY_BINDINGS', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/example/laravel/config/bugsnag.php
+++ b/example/laravel/config/bugsnag.php
@@ -90,15 +90,15 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Events
+    | Query
     |--------------------------------------------------------------------------
     |
-    | Enable this if you'd like us to automatically record all fired events as
-    | breadcrumbs. This includes both framework and user dispatched events.
+    | Enable this if you'd like us to automatically record all queries executed
+    | as breadcrumbs.
     |
     */
 
-    'events' => env('BUGSNAG_EVENTS', true),
+    'query' => env('BUGSNAG_QUERY', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/example/laravel/config/bugsnag.php
+++ b/example/laravel/config/bugsnag.php
@@ -98,7 +98,19 @@ return [
     |
     */
 
-    'query' => env('BUGSNAG_QUERY', false),
+    'query' => env('BUGSNAG_QUERY', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Bindings
+    |--------------------------------------------------------------------------
+    |
+    | Enable this if you'd like us to include the query bindings in our query
+    | breadcrumbs.
+    |
+    */
+
+    'bindings' => env('BUGSNAG_BINDINGS', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -75,7 +75,7 @@ class BugsnagServiceProvider extends ServiceProvider
             return;
         }
 
-        $show = isset($config['bindings']) && $config['bindings']);
+        $show = isset($config['bindings']) && $config['bindings'];
 
         if (class_exists(QueryExecuted::class)) {
             $events->listen(QueryExecuted::class, function (QueryExecuted $query) use ($show) {

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -114,7 +114,7 @@ class BugsnagServiceProvider extends ServiceProvider
             $data["binding {$index}"] = $binding;
         }
 
-        $data['time'] = "{$time} ms";
+        $data['time'] = "{$time}ms";
         $data['connection'] = $connection;
 
         return $data;

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -71,24 +71,26 @@ class BugsnagServiceProvider extends ServiceProvider
      */
     protected function setupEvents(Dispatcher $events, array $config)
     {
-        if (!isset($config['query']) || !$config['query']) {
+        if (isset($config['query']) && !$config['query']) {
             return;
         }
 
+        $show = isset($config['bindings']) && $config['bindings']);
+
         if (class_exists(QueryExecuted::class)) {
-            $events->listen(QueryExecuted::class, function (QueryExecuted $query) {
+            $events->listen(QueryExecuted::class, function (QueryExecuted $query) use ($show) {
                 $this->app->bugsnag->leaveBreadcrumb(
                     'Query executed',
                     Breadcrumb::PROCESS_TYPE,
-                    $this->formatQuery($query->sql, $query->bindings, $query->time, $query->connectionName)
+                    $this->formatQuery($query->sql, $show ? $query->bindings : [], $query->time, $query->connectionName)
                 );
             });
         } else {
-            $events->listen('illuminate.query', function ($sql, array $bindings, $time, $connection) {
+            $events->listen('illuminate.query', function ($sql, array $bindings, $time, $connection) use ($show) {
                 $this->app->bugsnag->leaveBreadcrumb(
                     'Query executed',
                     Breadcrumb::PROCESS_TYPE,
-                    $this->formatQuery($sql, $bindings, $time, $connection)
+                    $this->formatQuery($sql, $show ? $bindings : [], $time, $connection)
                 );
             });
         }

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -114,7 +114,7 @@ class BugsnagServiceProvider extends ServiceProvider
             $data["binding {$index}"] = $binding;
         }
 
-        $data['time'] = $time;
+        $data['time'] = "{$time} ms";
         $data['connection'] = $connection;
 
         return $data;

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -9,9 +9,9 @@ use Bugsnag\Callbacks\CustomUser;
 use Bugsnag\Client;
 use Bugsnag\Configuration;
 use Bugsnag\Report;
-use Exception;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\QueueManager;
@@ -71,17 +71,51 @@ class BugsnagServiceProvider extends ServiceProvider
      */
     protected function setupEvents(Dispatcher $events, array $config)
     {
-        if (isset($config['events']) && !$config['events']) {
+        if (!isset($config['query']) || !$config['query']) {
             return;
         }
 
-        $events->listen('*', function () use ($events) {
-            try {
-                $this->app->bugsnag->leaveBreadcrumb($events->firing(), Breadcrumb::STATE_TYPE);
-            } catch (Exception $e) {
-                //
-            }
-        });
+        if (class_exists(QueryExecuted::class)) {
+            $events->listen(QueryExecuted::class, function (QueryExecuted $query) {
+                $this->app->bugsnag->leaveBreadcrumb(
+                    'Query executed',
+                    Breadcrumb::PROCESS_TYPE,
+                    $this->formatQuery($query->sql, $query->bindings, $query->time, $query->connectionName)
+                );
+            });
+        } else {
+            $events->listen('illuminate.query', function ($sql, array $bindings, $time, $connection) {
+                $this->app->bugsnag->leaveBreadcrumb(
+                    'Query executed',
+                    Breadcrumb::PROCESS_TYPE,
+                    $this->formatQuery($sql, $bindings, $time, $connection)
+                );
+            });
+        }
+    }
+
+    /**
+     * Format the query as breadcrumb metadata.
+     *
+     * @param string $sql
+     * @param array  $bindings
+     * @param float  $time
+     * @param string $connection
+     *
+     * @return array
+     */
+    protected function formatQuery($sql, array $bindings, $time, $connection)
+    {
+        $data = ['sql' => $sql];
+
+        foreach ($bindings as $index => $binding) {
+            $data["binding {$index}"] = $binding;
+        }
+
+        $data['time'] = $time;
+        $data['connection'] = $connection;
+
+        return $data;
     }
 
     /**


### PR DESCRIPTION
Our other event logging implementation was far from satisfactory. Instead, we should add a detailed example in the docs showing how to record your own events as breadcrumbs.