### PR TITLE
Support Generic Users

### DIFF
--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -269,6 +269,10 @@ class BugsnagServiceProvider extends ServiceProvider
         if (!isset($config['user']) || $config['user']) {
             $client->registerCallback(new CustomUser(function () use ($app) {
                 if ($user = $app->auth->user()) {
+                    if (is_callable([$user, 'toArray'])) {
+                        return $user->toArray();
+                    }
+
                     if ($user instanceof GenericUser) {
                         $reflection = new ReflectionClass($user);
                         $property = $reflection->getProperty('attributes');
@@ -276,8 +280,6 @@ class BugsnagServiceProvider extends ServiceProvider
 
                         return $property->getValue($user);
                     }
-
-                    return $user->toArray();
                 }
             }));
         }


### PR DESCRIPTION
When using the database auth driver in Laravel the generic user does not have a `toArray()` method. Resulting in a white screen of death. 

Leaving with the options 
- You could turn off user in bugsnag and loss that information
- Create a registerUserResolver and do what this PR does

However, I feel enough users must experience this out of the box and just get a white screen. 

I have used reflection which seems less than ideal but open to ideas.

```
2016/10/03 14:25:21 [error] 2727#2727: *383 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught Error: Call to undefined method Illuminate\Auth\GenericUser::toArray() in /var/www/vendor/bugsnag/bugsnag-laravel/src/BugsnagServiceProvider.php:270
Stack trace:
#0 /var/www/vendor/bugsnag/bugsnag/src/Callbacks/CustomUser.php(41): Bugsnag\BugsnagLaravel\BugsnagServiceProvider->Bugsnag\BugsnagLaravel\{closure}()
#1 /var/www/vendor/bugsnag/bugsnag/src/Middleware/CallbackBridge.php(40): Bugsnag\Callbacks\CustomUser->__invoke(Object(Bugsnag\Report))
#2 [internal function]: Bugsnag\Middleware\CallbackBridge->__invoke(Object(Bugsnag\Report), Object(Closure))
#3 /var/www/vendor/bugsnag/bugsnag/src/Pipeline.php(68): call_user_func(Object(Bugsnag\Middleware\CallbackBridge), Object(Bugsnag\Report), Object(Closure))
#4 /var/www/vendor/bugsnag/bugsnag/src/Middleware/CallbackBridge.php(41): Bugsnag\Pipeline->Bugsnag\{closure}(Object(Bugsnag\Report))
#5 [internal function]: Bugsnag\Middleware\CallbackBridge->__invoke(Object(Bugsnag\Report), Object(Closure))
#6 /var/www/vendor/bug...
```
