### PR TITLE
Work around PHP phar realpath restrictions

### DIFF
--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -50,7 +50,7 @@ class BugsnagServiceProvider extends ServiceProvider
      */
     protected function setupConfig(Container $app)
     {
-        $source = realpath(__DIR__.'/../config/bugsnag.php');
+        $source = realpath($raw = __DIR__.'/../config/bugsnag.php') ?: $raw;
 
         if ($app instanceof LaravelApplication && $app->runningInConsole()) {
             $this->publishes([$source => config_path('bugsnag.php')]);


### PR DESCRIPTION
PHP's `realpath` function does not permit evaluating paths within "phar" files. This means that in our service provider, the `$source` variable is evaluated to `false` whenever someone tries to package up "bugsnag-laravel" in a "phar":

```php
    protected function setupConfig(Container $app)
    {
        $source = realpath(__DIR__.'/../config/bugsnag.php');

        if ($app instanceof LaravelApplication && $app->runningInConsole()) {
            $this->publishes([$source => config_path('bugsnag.php')]);
        } elseif ($app instanceof LumenApplication) {
            $app->configure('bugsnag');
        }

        $this->mergeConfigFrom($source, 'bugsnag');
    }
```

This can be mitigated by replacing the first line of the function body with:

```php
$source = realpath($raw = __DIR__.'/../config/bugsnag.php') ?: $raw;
```

since it's not absolutely required to use the "real path".

**This change just falls back to the relative path if we are not able to compute the real path.**

---

Closes #222. Related: https://bugs.php.net/bug.php?id=52769.

Thanks to @praalhans for the report.
