### PR TITLE
Get ClientIP from load balancer.

### DIFF
--- a/src/Request/LaravelRequest.php
+++ b/src/Request/LaravelRequest.php
@@ -73,7 +73,7 @@ class LaravelRequest implements RequestInterface
 
         $data['params'] = $this->request->input();
 
-        $data['clientIp'] = $this->request->getClientIp();
+        $data['clientIp'] = $this->getRequestIp();
 
         if ($agent = $this->request->header('User-Agent')) {
             $data['userAgent'] = $agent;
@@ -103,6 +103,20 @@ class LaravelRequest implements RequestInterface
      */
     public function getUserId()
     {
+        return $this->request->getClientIp();
+    }
+
+    /**
+     * Get the request ip.
+     *
+     * @return string|null
+     */
+    protected function getRequestIp()
+    {
+        if ($ip = $this->request->header('X-Forwarded-For')) {
+            return $ip;
+        }
+        
         return $this->request->getClientIp();
     }
 }

--- a/src/Request/LaravelRequest.php
+++ b/src/Request/LaravelRequest.php
@@ -116,7 +116,7 @@ class LaravelRequest implements RequestInterface
         if ($ip = $this->request->header('X-Forwarded-For')) {
             return $ip;
         }
-        
+
         return $this->request->getClientIp();
     }
 }


### PR DESCRIPTION
Copied from https://github.com/bugsnag/bugsnag-php/blob/master/src/Request/PhpRequest.php#L163

This resolves the issue where the clientIp is always the loadbalancer

<img width="447" alt="screen shot 2017-03-30 at 11 13 48 am" src="https://cloud.githubusercontent.com/assets/39970/24517519/e8b31b0a-153b-11e7-9c70-ae9612011835.png">