### PR TITLE
Enable Laravel 5.5 auto-discovery.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,14 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.4-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Bugsnag\\BugsnagLaravel\\BugsnagServiceProvider"
+            ],
+            "aliases": {
+                "Bugsnag": "Bugsnag\\BugsnagLaravel\\Facades\\Bugsnag"
+            }
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Enable Laravel 5.5 package auto-discovery:

---

See:

- https://medium.com/@taylorotwell/package-auto-discovery-in-laravel-5-5-ea9e3ab20518
- https://github.com/barryvdh/laravel-debugbar/pull/643