### PR TITLE
Support Laravel Auto-Discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,14 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.6-dev"
-        }
+        },
+    "laravel": {
+        "providers": [
+            "Bugsnag\\BugsnagLaravel\\BugsnagServiceProvider"
+         ],
+         "aliases": {
+            "Bugsnag": "Bugsnag\\BugsnagLaravel\\Facades\\Bugsnag"
+         }
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
This will make the package work with [auto-discovery](https://github.com/laravel/framework/pull/19420) in Laravel 5.5

Also, please release a new version of this package (you can release a patch or a minor version) when you merge this PR, to avoid pulling `dev-master` :wink:.

:octocat: