### PR TITLE
Use the handle method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": ">=5.5",
-        "illuminate/contracts": "^5.0.30",
-        "illuminate/support": "^5.0.30",
+        "illuminate/contracts": "^5.0",
+        "illuminate/support": "^5.0",
         "bugsnag/bugsnag": "^3.5",
         "bugsnag/bugsnag-psr-logger": "^1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": ">=5.5",
-        "illuminate/contracts": "^5.0",
-        "illuminate/support": "^5.0",
+        "illuminate/contracts": "^5.0.30",
+        "illuminate/support": "^5.0.30",
         "bugsnag/bugsnag": "^3.5",
         "bugsnag/bugsnag-psr-logger": "^1.1"
     },

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -35,6 +35,16 @@ class DeployCommand extends Command
     }
 
     /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        $this->handle();
+    }
+
+    /**
      * Get the console command options.
      *
      * @return array

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -27,7 +27,7 @@ class DeployCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         Bugsnag::deploy($this->option('repository'), $this->option('branch'), $this->option('revision'));
 


### PR DESCRIPTION
Because of the PR https://github.com/laravel/framework/pull/20024, the `fire` method isn't supported anymore and therefore it doesn't work with the upcoming 5.5 release.

`fire` has been replaced by `handle` since https://github.com/laravel/framework/commit/970836c5368642d975c56aa71f8aecafddcd3fd8 (version `5.0.30`).
Because of that, this PR is compatible down to version `5.0.30`.

I'm not sure if I should do something in the composer.json, maybe @GrahamCampbell can help me here 🙂