### PR TITLE
Only capture attributes when fetching user data

### DIFF
--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -269,8 +269,8 @@ class BugsnagServiceProvider extends ServiceProvider
         if (!isset($config['user']) || $config['user']) {
             $client->registerCallback(new CustomUser(function () use ($app) {
                 if ($user = $app->auth->user()) {
-                    if (is_callable([$user, 'toArray'])) {
-                        return $user->toArray();
+                    if (method_exists($user, 'attributesToArray') && is_callable([$user, 'attributesToArray'])) {
+                        return $user->attributesToArray();
                     }
 
                     if ($user instanceof GenericUser) {


### PR DESCRIPTION
When a user is connected to many other models, calling `toArray` can be intensive, and the data gathered may not be much more useful from a debugging perspective. This change reduces the overhead of fetching the user.