### PR TITLE
Add Laravel 5.5 auto discovery support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,14 @@
 {
     "name": "bugsnag/bugsnag-laravel",
     "description": "Official Bugsnag notifier for Laravel applications.",
-    "keywords": ["bugsnag", "exceptions", "errors", "logging", "tracking", "laravel"],
+    "keywords": [
+        "bugsnag",
+        "exceptions",
+        "errors",
+        "logging",
+        "tracking",
+        "laravel"
+    ],
     "homepage": "https://github.com/bugsnag/bugsnag-laravel",
     "license": "MIT",
     "authors": [
@@ -28,13 +35,21 @@
         }
     },
     "autoload-dev": {
-        "psr-4" : {
-            "Bugsnag\\BugsnagLaravel\\Tests\\" : "tests/"
+        "psr-4": {
+            "Bugsnag\\BugsnagLaravel\\Tests\\": "tests/"
         }
     },
     "extra": {
         "branch-alias": {
             "dev-master": "2.7-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Bugsnag\\BugsnagLaravel\\BugsnagServiceProvider"
+            ],
+            "aliases": {
+                "Bugsnag": "Bugsnag\\BugsnagLaravel\\Facades\\Bugsnag"
+            }
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Laravel 5.5 comes out officially today. As discussed [here](https://medium.com/@taylorotwell/package-auto-discovery-in-laravel-5-5-ea9e3ab20518), one of the new features is auto-discovery that removes the need to explicitly declare providers and aliases in the app's config/app.php.  Instead, it can be automatically set from the package.json's extra data.

I understand I should be sending unit tests with the PR, but I am unsure how to implement this kind of test. 

I did however successfully include my fork in a vanilla 5.5 project and it is why I am taking the liberty of submitting the PR anyways.