### PR TITLE
Release v2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## 2.7.2 (2017-09-22)
+
+### Bug Fixes
+
+* Fix regression in stacktrace resolution when using Laravel 5.5
+  [#246](https://github.com/bugsnag/bugsnag-laravel/issues/246)
+
 ## 2.7.1 (2017-08-18)
 
 ### Bug Fixes

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/contracts": "^5.0",
         "illuminate/support": "^5.0",
         "bugsnag/bugsnag": "^3.5",
-        "bugsnag/bugsnag-psr-logger": "^1.1"
+        "bugsnag/bugsnag-psr-logger": "^1.1.1"
     },
     "require-dev": {
         "graham-campbell/testbench": "^3.1",

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -27,7 +27,7 @@ class BugsnagServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    const VERSION = '2.7.1';
+    const VERSION = '2.7.2';
 
     /**
      * Boot the service provider.


### PR DESCRIPTION
Fixes stacktrace resolution for Laravel 5.5.

Fixes #246