### PR TITLE
register commands automatically

### DIFF
--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -41,6 +41,8 @@ class BugsnagServiceProvider extends ServiceProvider
         $this->setupEvents($this->app->events, $this->app->config->get('bugsnag'));
 
         $this->setupQueue($this->app->queue);
+        
+        $this->setupCommands();
     }
 
     /**
@@ -157,6 +159,18 @@ class BugsnagServiceProvider extends ServiceProvider
 
             $this->app->make(Tracker::class)->set($job);
         });
+    }
+    
+    /**
+     * Setup the commands.
+     *
+     * @return void
+     */
+    public function setupCommands()
+    {
+        $this->commands([
+            Commands\DeployCommand::class,
+        ]);
     }
 
     /**


### PR DESCRIPTION
this will make the service provider register the command, and then the user does not have to do it themselves in their `Consoler/Kernel.php`.

