### PR TITLE
Now autoloads service provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,11 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.7-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Bugsnag\\BugsnagLaravel\\BugsnagServiceProvider"
+            ]
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Service provider is now autoloaded for applications running Laravel 5.5.