### PR TITLE
Add logger notify level to Laravel configuration

### DIFF
--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -228,4 +228,18 @@ return [
 
     'user' => env('BUGSNAG_USER', true),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Logger Notify Level
+    |--------------------------------------------------------------------------
+    |
+    | This sets the level at which a logged message will trigger a notification
+    | to Bugsnag.  By default this level will be 'notice'.
+    |
+    | Must be one of the Psr\Log\LogLevel levels from the Psr specification.
+    |
+    */
+
+    'logger_notify_level' => env('BUGSNAG_LOGGER_LEVEL'),
+
 ];

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -204,7 +204,12 @@ class BugsnagServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton('bugsnag.logger', function (Container $app) {
-            return new LaravelLogger($app['bugsnag'], $app['events']);
+            $config = $app->config->get('bugsnag');
+            $logger = new LaravelLogger($app['bugsnag'], $app['events']);
+            if (isset($config['logger_notify_level'])) {
+                $logger->setNotifyLevel($config['logger_notify_level']);
+            }
+            return $logger;
         });
 
         $this->app->singleton('bugsnag.multi', function (Container $app) {

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -209,6 +209,7 @@ class BugsnagServiceProvider extends ServiceProvider
             if (isset($config['logger_notify_level'])) {
                 $logger->setNotifyLevel($config['logger_notify_level']);
             }
+
             return $logger;
         });
 


### PR DESCRIPTION
Adds an additional configuration option - `logger_notify_level` to laravel configuration to interface with the [bugsnag-psr-logger change](https://github.com/bugsnag/bugsnag-psr-logger/pull/27). Maps to `BUGSNAG_LOGGER_LEVEL` automatically.