### PR TITLE
Add Package Discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,14 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.7-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Bugsnag\\BugsnagLaravel\\BugsnagServiceProvider"
+            ],
+            "aliases": {
+                "Bugsnag": "Bugsnag\\BugsnagLaravel\\Facades\\Bugsnag"
+            }
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
According to [Laravel documentation](https://laravel.com/docs/5.5/packages#package-discovery), we can use **_Package Discovery_** feature in Laravel 5.5+. It does not affect previous version so it does not break anything.

> Instead of requiring users to manually add your service provider to the list, you may define the provider in the extra section of your package's composer.json file [...] Once your package has been configured for discovery, Laravel will automatically register its service providers and facades when it is installed, creating a convenient installation experience for your package's users.

So in a near future, you would be able to remove everything about Service Provider and Façades (or mark it as optional for old Laravel) in your [install guide](https://docs.bugsnag.com/platforms/php/laravel/).