### PR TITLE
Removed duplicate interface

### DIFF
--- a/src/LaravelLogger.php
+++ b/src/LaravelLogger.php
@@ -5,7 +5,7 @@ namespace Bugsnag\BugsnagLaravel;
 use Bugsnag\Client;
 use Bugsnag\PsrLogger\BugsnagLogger;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Logging\Log;
+use Psr\Log\LoggerInterface as Log;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 

--- a/src/MultiLogger.php
+++ b/src/MultiLogger.php
@@ -4,7 +4,7 @@ namespace Bugsnag\BugsnagLaravel;
 
 use Bugsnag\PsrLogger\MultiLogger as BaseLogger;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Logging\Log;
+use Psr\Log\LoggerInterface as Log;
 
 class MultiLogger extends BaseLogger implements Log
 {


### PR DESCRIPTION
The Illuminate\Contracts\Logging\Log interface has been removed in Laravel 5.6 since this interface was a total duplication of the Psr\Log\LoggerInterface interface, hence it is advisable to use the latter.