### PR TITLE
Support Laravel 5.6

### DIFF
--- a/src/LaravelLogger.php
+++ b/src/LaravelLogger.php
@@ -5,11 +5,11 @@ namespace Bugsnag\BugsnagLaravel;
 use Bugsnag\Client;
 use Bugsnag\PsrLogger\BugsnagLogger;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Logging\Log;
+use Psr\Log\LoggerInterface;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 
-class LaravelLogger extends BugsnagLogger implements Log
+class LaravelLogger extends BugsnagLogger implements LoggerInterface
 {
     use EventTrait;
 

--- a/src/MultiLogger.php
+++ b/src/MultiLogger.php
@@ -4,9 +4,9 @@ namespace Bugsnag\BugsnagLaravel;
 
 use Bugsnag\PsrLogger\MultiLogger as BaseLogger;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Logging\Log;
+use Psr\Log\LoggerInterface;
 
-class MultiLogger extends BaseLogger implements Log
+class MultiLogger extends BaseLogger implements LoggerInterface
 {
     use EventTrait;
 
@@ -36,7 +36,7 @@ class MultiLogger extends BaseLogger implements Log
     public function useFiles($path, $level = 'debug')
     {
         foreach ($this->loggers as $logger) {
-            if ($logger instanceof Log) {
+            if ($logger instanceof LoggerInterface) {
                 $logger->useFiles($path, $level);
             }
         }
@@ -54,7 +54,7 @@ class MultiLogger extends BaseLogger implements Log
     public function useDailyFiles($path, $days = 0, $level = 'debug')
     {
         foreach ($this->loggers as $logger) {
-            if ($logger instanceof Log) {
+            if ($logger instanceof LoggerInterface) {
                 $logger->useDailyFiles($path, $days, $level);
             }
         }


### PR DESCRIPTION
### The `Illuminate\Contracts\Logging\Log` Interface
This interface has been removed since this interface was a total duplication of the  `Psr\Log\LoggerInterface interface`. You should type-hint the `Psr\Log\LoggerInterface` interface instead.