### PR TITLE
Change `class_exists` to `interface_exists` when requesting logs

### DIFF
--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -227,7 +227,7 @@ class BugsnagServiceProvider extends ServiceProvider
 
         $this->app->singleton('bugsnag.logger', function (Container $app) {
             $config = $app->config->get('bugsnag');
-            $logger = class_exists(Log::class) ? new LaravelLogger($app['bugsnag'], $app['events']) : new BugsnagLogger($app['bugsnag']);
+            $logger = interface_exists(Log::class) ? new LaravelLogger($app['bugsnag'], $app['events']) : new BugsnagLogger($app['bugsnag']);
             if (isset($config['logger_notify_level'])) {
                 $logger->setNotifyLevel($config['logger_notify_level']);
             }
@@ -236,7 +236,7 @@ class BugsnagServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton('bugsnag.multi', function (Container $app) {
-            return class_exists(Log::class) ? new MultiLogger([$app['log'], $app['bugsnag.logger']], $app['events']) : new BaseMultiLogger([$app['log'], $app['bugsnag.logger']]);
+            return interface_exists(Log::class) ? new MultiLogger([$app['log'], $app['bugsnag.logger']], $app['events']) : new BaseMultiLogger([$app['log'], $app['bugsnag.logger']]);
         });
 
         if ($this->app['log'] instanceof LogManager) {
@@ -249,8 +249,8 @@ class BugsnagServiceProvider extends ServiceProvider
 
         $this->app->alias('bugsnag', Client::class);
         $this->app->alias('bugsnag.tracker', Tracker::class);
-        $this->app->alias('bugsnag.logger', class_exists(Log::class) ? LaravelLogger::class : BugsnagLogger::class);
-        $this->app->alias('bugsnag.multi', class_exists(Log::class) ? MultiLogger::class : BaseMultiLogger::class);
+        $this->app->alias('bugsnag.logger', interface_exists(Log::class) ? LaravelLogger::class : BugsnagLogger::class);
+        $this->app->alias('bugsnag.multi', interface_exists(Log::class) ? MultiLogger::class : BaseMultiLogger::class);
     }
 
     /**

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -8,10 +8,9 @@ use Bugsnag\BugsnagLaravel\Queue\Tracker;
 use Bugsnag\Client;
 use Bugsnag\PsrLogger\BugsnagLogger;
 use Bugsnag\PsrLogger\MultiLogger as BaseMultiLogger;
-use GrahamCampbell\TestBenchCore\MockeryTrait;
 use GrahamCampbell\TestBenchCore\ServiceProviderTrait;
-use Illuminate\Foundation\Application;
 use Illuminate\Contracts\Logging\Log;
+use Illuminate\Foundation\Application;
 use Mockery;
 
 class ServiceProviderTest extends AbstractTestCase
@@ -57,21 +56,23 @@ class ServiceProviderTest extends AbstractTestCase
 
         $app->shouldReceive('singleton')
             ->with('bugsnag.logger', \Mockery::on(
-                function($closure) use ($loggerClass) {
+                function ($closure) use ($loggerClass) {
                     if (is_callable($closure)) {
                         $internalApp = Mockery::mock(Application::class);
                         $config = Mockery::mock();
                         $internalApp->shouldReceive('offsetGet')->with('config')->andReturn($internalApp);
                         $internalApp->shouldReceive('get')->with('bugsnag')->andReturn([
-                            'logger_notify_level' => 'error'
+                            'logger_notify_level' => 'error',
                         ]);
                         $bugsnag = Mockery::mock(Client::class);
                         $internalApp->shouldReceive('offsetGet')->with('bugsnag')->andReturn($bugsnag);
                         $internalApp->shouldReceive('offsetGet')->with('events')->zeroOrMoreTimes();
                         $logger = call_user_func($closure, $internalApp);
                         $this->assertSame(get_class($logger), $loggerClass);
+
                         return true;
                     }
+
                     return false;
                 }
             ))
@@ -79,14 +80,16 @@ class ServiceProviderTest extends AbstractTestCase
 
         $app->shouldReceive('singleton')
             ->with('bugsnag.multi', \Mockery::on(
-                function($closure) use ($multiLoggerClass) {
+                function ($closure) use ($multiLoggerClass) {
                     if (is_callable($closure)) {
                         $internalApp = Mockery::mock(Application::class);
                         $internalApp->shouldReceive('offsetGet')->with(\Mockery::type('string'));
                         $multiLogger = call_user_func($closure, $internalApp);
                         $this->assertSame(get_class($multiLogger), $multiLoggerClass);
+
                         return true;
                     }
+
                     return false;
                 }
             ))

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -8,8 +8,11 @@ use Bugsnag\BugsnagLaravel\Queue\Tracker;
 use Bugsnag\Client;
 use Bugsnag\PsrLogger\BugsnagLogger;
 use Bugsnag\PsrLogger\MultiLogger as BaseMultiLogger;
+use GrahamCampbell\TestBenchCore\MockeryTrait;
 use GrahamCampbell\TestBenchCore\ServiceProviderTrait;
+use Illuminate\Foundation\Application;
 use Illuminate\Contracts\Logging\Log;
+use Mockery;
 
 class ServiceProviderTest extends AbstractTestCase
 {
@@ -27,11 +30,73 @@ class ServiceProviderTest extends AbstractTestCase
 
     public function testMultiLoggerIsInjectable()
     {
-        $this->assertIsInjectable(class_exists(Log::class) ? MultiLogger::class : BaseMultiLogger::class);
+        $this->assertIsInjectable(interface_exists(Log::class) ? MultiLogger::class : BaseMultiLogger::class);
     }
 
     public function testBugsnagLoggerIsInjectable()
     {
-        $this->assertIsInjectable(class_exists(Log::class) ? LaravelLogger::class : BugsnagLogger::class);
+        $this->assertIsInjectable(interface_exists(Log::class) ? LaravelLogger::class : BugsnagLogger::class);
+    }
+
+    public function testCorrectLoggerClassesReturned()
+    {
+        $app = Mockery::mock(Application::class);
+        $providerClass = $this->getServiceProviderClass($app);
+        $provider = new $providerClass($app);
+
+        $loggerClass = interface_exists(Log::class) ? LaravelLogger::class : BugsnagLogger::class;
+        $multiLoggerClass = interface_exists(Log::class) ? MultiLogger::class : BaseMultiLogger::class;
+
+        $app->shouldReceive('singleton')
+            ->with('bugsnag', \Mockery::type('callable'))
+            ->once();
+
+        $app->shouldReceive('singleton')
+            ->with('bugsnag.tracker', \Mockery::type('callable'))
+            ->once();
+
+        $app->shouldReceive('singleton')
+            ->with('bugsnag.logger', \Mockery::on(
+                function($closure) use ($loggerClass) {
+                    if (is_callable($closure)) {
+                        $internalApp = Mockery::mock(Application::class);
+                        $config = Mockery::mock();
+                        $internalApp->shouldReceive('offsetGet')->with('config')->andReturn($internalApp);
+                        $internalApp->shouldReceive('get')->with('bugsnag')->andReturn([
+                            'logger_notify_level' => 'error'
+                        ]);
+                        $bugsnag = Mockery::mock(Client::class);
+                        $internalApp->shouldReceive('offsetGet')->with('bugsnag')->andReturn($bugsnag);
+                        $internalApp->shouldReceive('offsetGet')->with('events')->zeroOrMoreTimes();
+                        $logger = call_user_func($closure, $internalApp);
+                        $this->assertSame(get_class($logger), $loggerClass);
+                        return true;
+                    }
+                    return false;
+                }
+            ))
+            ->once();
+
+        $app->shouldReceive('singleton')
+            ->with('bugsnag.multi', \Mockery::on(
+                function($closure) use ($multiLoggerClass) {
+                    if (is_callable($closure)) {
+                        $internalApp = Mockery::mock(Application::class);
+                        $internalApp->shouldReceive('offsetGet')->with(\Mockery::type('string'));
+                        $multiLogger = call_user_func($closure, $internalApp);
+                        $this->assertSame(get_class($multiLogger), $multiLoggerClass);
+                        return true;
+                    }
+                    return false;
+                }
+            ))
+            ->once();
+
+        $app->shouldReceive('offsetGet')->with('log')->andReturn(null);
+        $app->shouldReceive('alias')->with('bugsnag', Client::class)->once();
+        $app->shouldReceive('alias')->with('bugsnag.tracker', Tracker::class)->once();
+        $app->shouldReceive('alias')->with('bugsnag.logger', $loggerClass)->once();
+        $app->shouldReceive('alias')->with('bugsnag.multi', $multiLoggerClass)->once();
+        $provider->register();
     }
 }


### PR DESCRIPTION
Changes `class_exists` calls on `Illuminate\Contracts\Logging\Log` to `interface_exists` to ensure the correct logger is returned.