### PR TITLE
Laravel package autodiscovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,14 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.15-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Bugsnag\\BugsnagLaravel\\BugsnagServiceProvider"
+            ],
+            "aliases": {
+                "Bugsnag": "Bugsnag\\BugsnagLaravel\\Facades\\Bugsnag"
+            }
         }
     },
     "minimum-stability": "dev",

--- a/example/laravel56/config/app.php
+++ b/example/laravel56/config/app.php
@@ -150,7 +150,6 @@ return [
         /*
          * Package Service Providers...
          */
-        Bugsnag\BugsnagLaravel\BugsnagServiceProvider::class,
 
         /*
          * Application Service Providers...
@@ -209,7 +208,6 @@ return [
         'URL' => Illuminate\Support\Facades\URL::class,
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,
-        'Bugsnag' => Bugsnag\BugsnagLaravel\Facades\Bugsnag::class,
 
     ],
 


### PR DESCRIPTION
Since Laravel 5.5, you can use [the autodiscovery feature](https://laravel.com/docs/5.6/packages#package-discovery) to add packages more easily.

If you merge this request, you can make the addition to the "providers" and "aliases" array optional for Laravel 5.5+.
