### PR TITLE
Add phpDoc method tags

### DIFF
--- a/src/Facades/Bugsnag.php
+++ b/src/Facades/Bugsnag.php
@@ -4,6 +4,24 @@ namespace Bugsnag\BugsnagLaravel\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * @method static \Bugsnag\Client make(string|null $apiKey, string|null $endpoint, bool $defaults)
+ * @method static \GuzzleHttp\ClientInterface make(string|null $base, array $options)
+ * @method static string|false getCaBundlePath()
+ * @method static \Bugsnag\Configuration getConfig()
+ * @method static $this registerCallback(callable $callback)
+ * @method static $this registerDefaultCallbacks()
+ * @method static void leaveBreadcrumb(string $name, string|null $type, array $metaData)
+ * @method static void clearBreadcrumbs()
+ * @method static void notifyException(\Throwable $throwable, callable|null $callback)
+ * @method static void notifyError(string $name, string $message, callable|null $callback)
+ * @method static void notify(\Bugsnag\Report $report, callable|null $callback)
+ * @method static void deploy(string|null $repository, string|null $branch, string|null $revision)
+ * @method static void build(string|null $repository, string|null $revision, string|null $provider, string|null $builderName)
+ * @method static void flush()
+ * @method static void startSession()
+ * @method static \Bugsnag\SessionTracker getSessionTracker()
+ */
 class Bugsnag extends Facade
 {
     protected static function getFacadeAccessor()


### PR DESCRIPTION
## Goal

Synthesise client methods on façade to enable autocomplete in IDEs that read phpDoc tags.

## Tests

Tested in IDE (Visual Studio Code) by adding the phpDoc tags to façade in my application’s vendor directory. Type-hints were read and methods offered as suggestions as intended.

## Review

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language