### PR TITLE
Dockerisation: Added dockerfile and updated Readme

### DIFF
--- a/example/laravel56/.dockerignore
+++ b/example/laravel56/.dockerignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/example/laravel56/Dockerfile
+++ b/example/laravel56/Dockerfile
@@ -1,16 +1,18 @@
 FROM php:latest
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends git zip unzip wget
+  apt-get install -y --no-install-recommends \
+  git \
+  unzip \
+  wget \
+  zip
 
-RUN mkdir /app
 WORKDIR /app
 
-COPY . /app/
+COPY . .
 
-RUN /app/install_composer.sh
+RUN ./install_composer.sh
 
-RUN cd /app/ && \
-  php composer.phar install
+RUN php composer.phar install
 
 CMD php artisan serve --port=8000 --host=0.0.0.0

--- a/example/laravel56/Dockerfile
+++ b/example/laravel56/Dockerfile
@@ -15,4 +15,6 @@ RUN ./install_composer.sh
 
 RUN php composer.phar install
 
+RUN php artisan key:generate
+
 CMD php artisan serve --port=8000 --host=0.0.0.0

--- a/example/laravel56/Dockerfile
+++ b/example/laravel56/Dockerfile
@@ -1,0 +1,8 @@
+FROM php:latest
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY . /app/
+
+CMD php artisan serve --port=8000 --host=0.0.0.0

--- a/example/laravel56/Dockerfile
+++ b/example/laravel56/Dockerfile
@@ -1,8 +1,16 @@
 FROM php:latest
 
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends git zip unzip wget
+
 RUN mkdir /app
 WORKDIR /app
 
 COPY . /app/
+
+RUN /app/install_composer.sh
+
+RUN cd /app/ && \
+  php composer.phar install
 
 CMD php artisan serve --port=8000 --host=0.0.0.0

--- a/example/laravel56/install_composer.sh
+++ b/example/laravel56/install_composer.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE="$(php -r "echo hash_file('SHA384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php
+RESULT=$?
+rm composer-setup.php
+exit $RESULT

--- a/example/laravel56/readme.md
+++ b/example/laravel56/readme.md
@@ -34,16 +34,23 @@ For more information, see [our Laravel documentation](https://docs.bugsnag.com/p
 
 ## Running in Docker
 
-To start the example in docker, follow the steps as above.  Then, instead of starting the site using `php artisan serve`, run the docker command:
+1. As above, clone the repo and `cd` into this directory:
+    ```shell
+    git clone https://github.com/bugsnag/bugsnag-laravel.git
+    cd bugsnag-laravel/example/laravel56
+    ```
 
-```shell
-docker build .
-```
+1. Then ensure that your Bugsnag Api Key is set in the `.env` file within the application.  If you do not have a `.env` file present, move the    `.env.example` file to `.env`, and add the `BUGSNAG_API_KEY` environment variable, setting it to your Api Key.
 
-Then start your newly built container, with a port forwarding from your local machine to port `8000` in the container, for example:
+1. Build the container:
+    ```shell
+    docker build -t bugsnag-example-app .
+    ```
 
-```shell
-docker run -d -p 8000:8000 <YOUR CONTAINER NUMBER>
-```
+1. Then start your newly built container, with a port forwarding from your local machine to port `8000` in the container, for example:
 
-Then you can head to http://localhost:8000 to see the example page.
+    ```shell
+    docker run -d -p 8000:8000 bugsnag-example-app
+    ```
+
+1. View the example page which will, by default, be served at: http://localhost:8000

--- a/example/laravel56/readme.md
+++ b/example/laravel56/readme.md
@@ -1,59 +1,49 @@
-<p align="center"><img src="https://laravel.com/assets/img/components/logo-laravel.svg"></p>
+# Bugsnag Laravel 5.6 demo
 
-<p align="center">
-<a href="https://travis-ci.org/laravel/framework"><img src="https://travis-ci.org/laravel/framework.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://poser.pugx.org/laravel/framework/d/total.svg" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://poser.pugx.org/laravel/framework/v/stable.svg" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://poser.pugx.org/laravel/framework/license.svg" alt="License"></a>
-</p>
+This Laravel application demonstrates how to use Bugsnag with the Laravel web framework for PHP.
 
-## About Laravel
+## Setup
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel attempts to take the pain out of development by easing common tasks used in the majority of web projects, such as:
+Try this out with [your own Bugsnag account](https://app.bugsnag.com/user/new), and you'll be able to see how the errors are reported directly in the dashboard.
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+To get set up, follow the instructions below. Don't forget to replace the placeholder API token with your own!
 
-Laravel is accessible, yet powerful, providing tools needed for large, robust applications.
 
-## Learning Laravel
+1. Clone the repo and `cd` into this directory:
+    ```shell
+    git clone https://github.com/bugsnag/bugsnag-laravel.git
+    cd bugsnag-laravel/example/laravel56
+    ```
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of any modern web application framework, making it a breeze to get started learning the framework.
+1. Install dependencies
+    ```shell
+    composer install
+    ```
 
-If you're not in the mood to read, [Laracasts](https://laracasts.com) contains over 1100 video tutorials on a range of topics including Laravel, modern PHP, unit testing, JavaScript, and more. Boost the skill level of yourself and your entire team by digging into our comprehensive video library.
+1. Ensure that your Bugsnag Api Key is set in the `.env` file within the application.  If you do not have a `.env` file present, move the `.env.example` file to `.env`, and add the `BUGSNAG_API_KEY` environment variable, setting it to your Api Key.
 
-## Laravel Sponsors
+1. Run the application.
+    ```shell
+    php artisan serve
+    ```
 
-We would like to extend our thanks to the following sponsors for helping fund on-going Laravel development. If you are interested in becoming a sponsor, please visit the Laravel [Patreon page](https://patreon.com/taylorotwell):
+1. View the example page which will, by default, be served at: http://localhost:8000
 
-- **[Vehikl](https://vehikl.com/)**
-- **[Tighten Co.](https://tighten.co)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[British Software Development](https://www.britishsoftware.co)**
-- [Fragrantica](https://www.fragrantica.com)
-- [SOFTonSOFA](https://softonsofa.com/)
-- [User10](https://user10.com)
-- [Soumettre.fr](https://soumettre.fr/)
-- [CodeBrisk](https://codebrisk.com)
-- [1Forge](https://1forge.com)
-- [TECPRESSO](https://tecpresso.co.jp/)
-- [Pulse Storm](http://www.pulsestorm.net/)
-- [Runtime Converter](http://runtimeconverter.com/)
-- [WebL'Agence](https://weblagence.com/)
+For more information, see [our Laravel documentation](https://docs.bugsnag.com/platforms/php/laravel/).
 
-## Contributing
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+## Running in Docker
 
-## Security Vulnerabilities
+To start the example in docker, follow the steps as above.  Then, instead of starting the site using `php artisan serve`, run the docker command:
 
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
+```shell
+docker build .
+```
 
-## License
+Then start your newly built container, with a port forwarding from your local machine to port `8000` in the container, for example:
 
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+```shell
+docker run -d -p 8000:8000 <YOUR CONTAINER NUMBER>
+```
+
+Then you can head to http://localhost:8000 to see the example page.

--- a/example/laravel56/resources/views/welcome.blade.php
+++ b/example/laravel56/resources/views/welcome.blade.php
@@ -66,28 +66,17 @@
     </head>
     <body>
         <div class="flex-center position-ref full-height">
-            @if (Route::has('login'))
-                <div class="top-right links">
-                    @auth
-                        <a href="{{ url('/home') }}">Home</a>
-                    @else
-                        <a href="{{ route('login') }}">Login</a>
-                        <a href="{{ route('register') }}">Register</a>
-                    @endauth
-                </div>
-            @endif
-
             <div class="content">
                 <div class="title m-b-md">
-                    Laravel
+                    Bugsnag Laravel example
                 </div>
 
                 <div class="links">
-                    <a href="https://laravel.com/docs">Documentation</a>
-                    <a href="https://laracasts.com">Laracasts</a>
-                    <a href="https://laravel-news.com">News</a>
-                    <a href="https://forge.laravel.com">Forge</a>
-                    <a href="https://github.com/laravel/laravel">GitHub</a>
+                    <a href="/crash">Crash</a>
+                    <a href="/notify">Notify</a>
+                    <a href="/metadata">Crash with added metadata</a>
+                    <a href="/notifywithmetadata">Notify with added metadata</a>
+                    <a href="/severity">Notify with modified severity</a>
                 </div>
             </div>
         </div>

--- a/example/laravel56/routes/web.php
+++ b/example/laravel56/routes/web.php
@@ -15,6 +15,42 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::get('test', function () {
-    throw new Exception('Example exception!');
+Route::get('crash', function () {
+    throw new Exception('Crashing exception!');
+});
+
+Route::get('notify', function () {
+    Bugsnag::notifyException(new Exception('A notified exception'));
+    return "An exception has been notified.  Check your dashboard to view it!";
+});
+
+Route::get('metadata', function () {
+    Bugsnag::registerCallback(function($report) {
+        $report->setMetaData([
+            'routeDetails' => [
+                'path' => 'metadata',
+                'function' => 'Adds a callback to Bugsnag that adds metadata to a notification'
+            ]
+        ]);
+    });
+    throw new Exception('Metadata exception!');
+});
+
+Route::get('notifywithmetadata', function () {
+    Bugsnag::notifyException(new Exception('A notified exception'), function($report) {
+        $report->setMetaData([
+            'routeDetails' => [
+                'path' => 'notifywithmetadata',
+                'function' => 'Shows how to send extra data with a manually notified exception!'
+            ]
+        ]);
+    });
+    return "An exception has been notified.  Check your dashboard to view it!";
+});
+
+Route::get('severity', function () {
+    Bugsnag::notifyException(new Exception('A notified exception'), function($report) {
+        $report->setSeverity("info");
+    });
+    return "An exception has been notified.  Check your dashboard to view it!";
 });


### PR DESCRIPTION
Adds a basic dockerfile to the Laravel 5.6 example, allow it to be run in a local container.

This not only will allow us to get the examples running inside a container faster, but also is a stepping stone toward end-to-end/maze tests.

An updated readme for the example has also been provided.

## Tests

The docker container was manually run, and confirmed to be delivering notifications to Bugsnag.

## Review

The example needs to be tested so that the example can be built and run out of the box.