### PR TITLE
DockerDelay: Added delay before pings after docker-composer up

### DIFF
--- a/features/handled_controller.feature
+++ b/features/handled_controller.feature
@@ -4,6 +4,7 @@ Scenario: Handled exceptions are delivered from controllers
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/handled_controller_exception" on port "61280"
   And I wait for 1 second
@@ -24,6 +25,7 @@ Scenario: Handled errors are delivered from controllers
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/handled_controller_error" on port "61280"
   And I wait for 1 second
@@ -45,6 +47,7 @@ Scenario: Sessions are correct in handled exceptions from controllers
   And I configure the bugsnag endpoint
   And I enable session tracking
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/handled_controller_exception" on port "61280"
   And I wait for 1 second

--- a/features/handled_middleware.feature
+++ b/features/handled_middleware.feature
@@ -4,6 +4,7 @@ Scenario: Handled exceptions are delivered from middleware
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/handled_middleware_exception" on port "61280"
   And I wait for 1 second
@@ -24,6 +25,7 @@ Scenario: Handled errors are delivered from middleware
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/handled_middleware_error" on port "61280"
   And I wait for 1 second
@@ -45,6 +47,7 @@ Scenario: Sessions are correct in handled exceptions from middleware
   And I configure the bugsnag endpoint
   And I enable session tracking
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/handled_middleware_exception" on port "61280"
   And I wait for 1 second

--- a/features/handled_routing.feature
+++ b/features/handled_routing.feature
@@ -4,6 +4,7 @@ Scenario: Handled exceptions are delivered from routing
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/handled_exception" on port "61280"
   And I wait for 1 second
@@ -24,6 +25,7 @@ Scenario: Handled errors are delivered from routing
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/handled_error" on port "61280"
   And I wait for 1 second
@@ -45,6 +47,7 @@ Scenario: Sessions are correct in handled exceptions from routing
   And I configure the bugsnag endpoint
   And I enable session tracking
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/handled_exception" on port "61280"
   And I wait for 1 second

--- a/features/unhandled_controller.feature
+++ b/features/unhandled_controller.feature
@@ -4,6 +4,7 @@ Scenario: Unhandled exceptions are delivered from controllers
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/unhandled_controller_exception" on port "61280"
   And I wait for 1 second
@@ -25,6 +26,7 @@ Scenario: Unhandled errors are delivered from controllers
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/unhandled_controller_error" on port "61280"
   And I wait for 1 second
@@ -47,6 +49,7 @@ Scenario: Sessions are correct in unhandled exceptions from controllers
   And I configure the bugsnag endpoint
   And I enable session tracking
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/unhandled_controller_exception" on port "61280"
   And I wait for 1 second

--- a/features/unhandled_middleware.feature
+++ b/features/unhandled_middleware.feature
@@ -4,6 +4,7 @@ Scenario: Unhandled exceptions are delivered from middleware
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/unhandled_middleware_exception" on port "61280"
   And I wait for 1 second
@@ -25,6 +26,7 @@ Scenario: Unhandled errors are delivered from middleware
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/unhandled_middleware_error" on port "61280"
   And I wait for 1 second
@@ -47,6 +49,7 @@ Scenario: Sessions are correct in unhandled exceptions from middleware
   And I configure the bugsnag endpoint
   And I enable session tracking
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/unhandled_middleware_exception" on port "61280"
   And I wait for 1 second

--- a/features/unhandled_routing.feature
+++ b/features/unhandled_routing.feature
@@ -4,6 +4,7 @@ Scenario: Unhandled exceptions are delivered from routing
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/unhandled_exception" on port "61280"
   And I wait for 1 second
@@ -25,6 +26,7 @@ Scenario: Unhandled errors are delivered from routing
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/unhandled_error" on port "61280"
   And I wait for 1 second
@@ -47,6 +49,7 @@ Scenario: Sessions are correct in unhandled exceptions from routing
   And I configure the bugsnag endpoint
   And I enable session tracking
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/unhandled_exception" on port "61280"
   And I wait for 1 second

--- a/features/unhandled_view.feature
+++ b/features/unhandled_view.feature
@@ -4,6 +4,7 @@ Scenario: Unhandled exceptions are delivered from views
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/unhandled_view_exception" on port "61280"
   And I wait for 1 second
@@ -25,6 +26,7 @@ Scenario: Unhandled errors are delivered from views
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/unhandled_view_error" on port "61280"
   And I wait for 1 second
@@ -47,6 +49,7 @@ Scenario: Sessions are correct in unhandled exceptions from views
   And I configure the bugsnag endpoint
   And I enable session tracking
   And I start the service "laravel"
+  And I wait for 3 seconds
   And I wait for the app to respond on port "61280"
   When I navigate to the route "/unhandled_view_exception" on port "61280"
   And I wait for 1 second


### PR DESCRIPTION
## Goal
Previous runs on CI have flakily failed with a `Connection reset by peer` error. Discussion led us to believe this was caused by pings being delivered too soon to the docker host, so this PR adds a timeout to allow the container to properly initialize before any messages are sent to it.