### PR TITLE
Remove duplicate `app["events"]` dispatch from `MultiLogger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBA
+
+### Fixes
+
+* Removed duplicate event dispatching when using MultiLogger configuration
+  [#337](https://github.com/bugsnag/bugsnag-laravel/pull/337)
+
 ## 2.15.1 (2018-11-05)
 
 ### Fixes

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -238,7 +238,7 @@ class BugsnagServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton('bugsnag.multi', function (Container $app) {
-            return interface_exists(Log::class) ? new MultiLogger([$app['log'], $app['bugsnag.logger']], $app['events']) : new BaseMultiLogger([$app['log'], $app['bugsnag.logger']]);
+            return interface_exists(Log::class) ? new MultiLogger([$app['log'], $app['bugsnag.logger']]) : new BaseMultiLogger([$app['log'], $app['bugsnag.logger']]);
         });
 
         if ($this->app['log'] instanceof LogManager) {


### PR DESCRIPTION
### Goal

Removes the `app['events']` dispatcher from the `MultiLogger` setup, as it's already present in the `LaravelLogger`, preventing duplicate `events` being fired.

Fixes #306 