### PR TITLE
Fix broken maze tests

### DIFF
--- a/features/unhandled_controller.feature
+++ b/features/unhandled_controller.feature
@@ -33,7 +33,8 @@ Scenario: Unhandled errors are delivered from controllers
   And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the payload field "events" is an array with 1 element
   And the exception "errorClass" ends with "FatalThrowableError"
-  And the exception "message" equals "Call to undefined function App\Http\Controllers\foo()"
+  And the exception "message" starts with "Call to undefined function"
+  And the exception "message" ends with "foo()"
   And the event "metaData.request.httpMethod" equals "GET"
   And the event "app.type" equals "HTTP"
   And the event "context" equals "GET /unhandled_controller_error"

--- a/features/unhandled_middleware.feature
+++ b/features/unhandled_middleware.feature
@@ -33,7 +33,8 @@ Scenario: Unhandled errors are delivered from middleware
   And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the payload field "events" is an array with 1 element
   And the exception "errorClass" ends with "FatalThrowableError"
-  And the exception "message" equals "Call to undefined function App\Http\Middleware\foo()"
+  And the exception "message" starts with "Call to undefined function"
+  And the exception "message" ends with "foo()"
   And the event "metaData.request.httpMethod" equals "GET"
   And the event "app.type" equals "HTTP"
   And the event "context" equals "GET /unhandled_middleware_error"


### PR DESCRIPTION
## Goal

Fix maze tests breaking as a result of a changing error message between laravel 5.6.12 and 5.6.21