### PR TITLE
Add runtime version MazeRunner tests

### DIFF
--- a/features/runtime_versions.feature
+++ b/features/runtime_versions.feature
@@ -4,7 +4,7 @@ Background:
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
 
-Scenario: report for unhandled event contains runtime version information
+Scenario: report for handled event contains runtime version information
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the laravel fixture
@@ -17,7 +17,7 @@ Scenario: report for unhandled event contains runtime version information
   And the event "device.runtimeVersions.php" matches "(\d+\.){2}\d+"
   And the event "device.runtimeVersions.laravel" matches "(\d+\.){2}\d+"
 
-Scenario: report for handled event contains runtime version information
+Scenario: report for unhandled event contains runtime version information
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I start the laravel fixture
@@ -30,7 +30,7 @@ Scenario: report for handled event contains runtime version information
   And the event "device.runtimeVersions.php" matches "(\d+\.){2}\d+"
   And the event "device.runtimeVersions.laravel" matches "(\d+\.){2}\d+"
 
-Scenario: Sessions are correct in unhandled exceptions from controllers
+Scenario: session payload contains runtime version information
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoint
   And I enable session tracking

--- a/features/runtime_versions.feature
+++ b/features/runtime_versions.feature
@@ -1,0 +1,45 @@
+Feature: Reporting runtime versions
+
+Background:
+  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag endpoint
+
+Scenario: report for unhandled event contains runtime version information
+  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag endpoint
+  And I start the laravel fixture
+  And I wait for the app to respond on the appropriate port
+  When I navigate to the route "/handled_exception"
+  And I wait for 1 second
+  Then I should receive a request
+  And the request is a valid for the error reporting API
+  And the event "unhandled" is false
+  And the event "device.runtimeVersions.php" matches "(\d+\.){2}\d+"
+  And the event "device.runtimeVersions.laravel" matches "(\d+\.){2}\d+"
+
+Scenario: report for handled event contains runtime version information
+  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag endpoint
+  And I start the laravel fixture
+  And I wait for the app to respond on the appropriate port
+  When I navigate to the route "/unhandled_exception"
+  And I wait for 1 second
+  Then I should receive a request
+  And the request is a valid for the error reporting API
+  And the event "unhandled" is true
+  And the event "device.runtimeVersions.php" matches "(\d+\.){2}\d+"
+  And the event "device.runtimeVersions.laravel" matches "(\d+\.){2}\d+"
+
+Scenario: Sessions are correct in unhandled exceptions from controllers
+  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag endpoint
+  And I enable session tracking
+  And I start the laravel fixture
+  And I wait for the app to respond on the appropriate port
+  When I navigate to the route "/unhandled_controller_exception"
+  And I wait for 1 second
+  Then I should receive 2 requests
+  And the request 0 is valid for the session tracking API
+  And the payload has a valid sessions array for request 0
+  And the payload field "device.runtimeVersions.php" matches the regex "(\d+\.){2}\d+"
+  And the payload field "device.runtimeVersions.laravel" matches the regex "(\d+\.){2}\d+"


### PR DESCRIPTION
## Goal

Add tests to cover the runtime version information now stored in device data.

## Changeset

### Added

* features/runtime_versions.feature - new test to check for the presence of a version string

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
