### PR TITLE
fix(SessionTracker): remove automatic session capturing for Lumen 5.3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Fixes
+
+* Disabled automatic session capturing for Lumen 5.3+ (where `session()` is not available)
+  [#358](https://github.com/bugsnag/bugsnag-laravel/pull/358)
+
 ## 2.16.0 (2019-06-17)
 
 ### Enhancements
@@ -8,7 +15,7 @@ Changelog
 * Add Laravel/Lumen version string to report and session payloads (device.runtimeVersions)
   [#352](https://github.com/bugsnag/bugsnag-laravel/pull/352)
 
-## Fixes
+### Fixes
 
 * Changed caching TTL to use DateTime instead. 
   [#344](https://github.com/bugsnag/bugsnag-laravel/pull/344)

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -372,6 +372,12 @@ class BugsnagServiceProvider extends ServiceProvider
      */
     protected function setupSessionTracking(Client $client, $endpoint, $events)
     {
+        // Session support removed in Lumen 5.3 - only setup automatic session
+        // tracking if the session function is avaiable
+        if (!function_exists('session')) {
+            return;
+        }
+
         $client->setAutoCaptureSessions(true);
         if (!is_null($endpoint)) {
             $client->setSessionEndpoint($endpoint);

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -12,6 +12,7 @@ use Bugsnag\Configuration;
 use Bugsnag\PsrLogger\BugsnagLogger;
 use Bugsnag\PsrLogger\MultiLogger as BaseMultiLogger;
 use Bugsnag\Report;
+use DateTime;
 use Illuminate\Auth\GenericUser;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -27,7 +28,6 @@ use Laravel\Lumen\Application as LumenApplication;
 use Monolog\Handler\PsrHandler;
 use Monolog\Logger;
 use ReflectionClass;
-use DateTime;
 
 class BugsnagServiceProvider extends ServiceProvider
 {
@@ -422,8 +422,8 @@ class BugsnagServiceProvider extends ServiceProvider
         if (preg_match('/(\d+\.\d+\.\d+)/', $version, $versionMatches)) {
             $version = $versionMatches[0];
         }
-        return [ ($this->app instanceof LumenApplication ? 'lumen' : 'laravel' ) => $version ];
 
+        return [($this->app instanceof LumenApplication ? 'lumen' : 'laravel') => $version];
     }
 
     /**


### PR DESCRIPTION
## Goal

`session()` is not available after Lumen 5.3 - this change prevents session tracking setup if the
method is not available.

## Changeset

### Changed

- BugsnagServiceProvider: setupSessionTracking now does nothing if `session` is not available.

## Tests

Manually tested that no exception occurs on Lumen and that session information continues to work on Laravel.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
