### PR TITLE
ci: Changed to trusty dist for PHP 5.5*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,22 @@ sudo: false
 matrix:
   include:
     - php: 5.5.9
+      dist: trusty
       env:
         - GUZZLE_VERSION=^5.3
         - LARAVEL_VERSION=5.1.*
     - php: 5.5.9
+      dist: trusty
       env:
         - GUZZLE_VERSION=^6.0
         - LARAVEL_VERSION=5.1.*
     - php: 5.5
+      dist: trusty
       env:
         - GUZZLE_VERSION=^5.3
         - LARAVEL_VERSION=5.1.*
     - php: 5.5
+      dist: trusty
       env:
         - GUZZLE_VERSION=^6.0
         - LARAVEL_VERSION=5.1.*


### PR DESCRIPTION
## Goal

Amended PHP distributions for 5.5 to `trusty` as Travis no longer work on Xenial.

## Changeset

### Changed

* Added `trusty` to all 5.5 builds in Travis config

## Tests

Tests now build and and run on CI.