### PR TITLE
Reduced the overhead of the bugsnag service provider

### DIFF
--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -49,7 +49,9 @@ class BugsnagServiceProvider extends ServiceProvider
 
         $this->setupEvents($this->app->events, $this->app->config->get('bugsnag'));
 
-        $this->setupQueue($this->app->queue);
+        if ($this->app->runningInConsole()) {
+            $this->setupQueue($this->app->queue);
+        }
     }
 
     /**


### PR DESCRIPTION
We don't need to attach Bugsnag's queue stuff if the current context is processing an HTTP request. This actually takes a significant amount of time, since it has to boot the queue service provider, and if the app never uses the queue, this is a waste of time.

<img width="1201" alt="image" src="https://user-images.githubusercontent.com/2829600/71322243-5adbe200-24bd-11ea-8049-65beb0af8718.png">
