### PR TITLE
Laravel 7 and more rigorous testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.idea
 Gemfile.lock
 maze_output
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,8 +112,7 @@ matrix:
       before_install: ruby --version
       install: bundle install
       script: bundle exec bugsnag-maze-runner -c
-      env:
-        - LARAVEL_FIXTURE=laravel56
+      env: LARAVEL_FIXTURE=laravel56
     - addons:
         apt:
           packages:
@@ -125,8 +124,7 @@ matrix:
       before_install: ruby --version
       install: bundle install
       script: bundle exec bugsnag-maze-runner -c
-      env:
-        - LARAVEL_FIXTURE=laravel58
+      env: LARAVEL_FIXTURE=laravel58
     - addons:
         apt:
           packages:
@@ -138,11 +136,10 @@ matrix:
       before_install: ruby --version
       install: bundle install
       script: bundle exec bugsnag-maze-runner -c
-      env:
-        - LARAVEL_FIXTURE=laravel66
+      env: LARAVEL_FIXTURE=laravel66
 
 before_install:
-  - composer require "laravel/framework:${LARAVEL_VERSION}" --no-update
+  - travis_retry composer require "laravel/framework:${LARAVEL_VERSION}" --no-update
   - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,143 +1,106 @@
 language: php
 
-sudo: false
-
 matrix:
   include:
     - php: 5.5.9
       dist: trusty
-      env:
-        - GUZZLE_VERSION=^5.3
-        - LARAVEL_VERSION=5.1.*
-    - php: 5.5.9
-      dist: trusty
-      env:
-        - GUZZLE_VERSION=^6.0
-        - LARAVEL_VERSION=5.1.*
+      env: LARAVEL_VERSION=5.1.*
     - php: 5.5
       dist: trusty
-      env:
-        - GUZZLE_VERSION=^5.3
-        - LARAVEL_VERSION=5.1.*
+      env: LARAVEL_VERSION=5.1.*
     - php: 5.5
       dist: trusty
-      env:
-        - GUZZLE_VERSION=^6.0
-        - LARAVEL_VERSION=5.1.*
+      env: LARAVEL_VERSION=5.2.*
     - php: 5.6
-      env:
-        - GUZZLE_VERSION=^5.3
-        - LARAVEL_VERSION=5.4.*
+      dist: xenial
+      env: LARAVEL_VERSION=5.1.*
     - php: 5.6
-      env:
-        - GUZZLE_VERSION=^6.0
-        - LARAVEL_VERSION=5.4.*
+      dist: xenial
+      env: LARAVEL_VERSION=5.2.*
+    - php: 5.6
+      dist: xenial
+      env: LARAVEL_VERSION=5.3.*
+    - php: 5.6
+      dist: xenial
+      env: LARAVEL_VERSION=5.4.*
     - php: 7.0
-      env:
-        - GUZZLE_VERSION=^5.3
-        - LARAVEL_VERSION=5.5.*
+      dist: xenial
+      env: LARAVEL_VERSION=5.1.*
     - php: 7.0
-      env:
-        - GUZZLE_VERSION=^6.0
-        - LARAVEL_VERSION=5.5.*
+      dist: xenial
+      env: LARAVEL_VERSION=5.2.*
+    - php: 7.0
+      dist: xenial
+      env: LARAVEL_VERSION=5.3.*
+    - php: 7.0
+      dist: xenial
+      env: LARAVEL_VERSION=5.4.*
+    - php: 7.0
+      dist: xenial
+      env: LARAVEL_VERSION=5.5.*
     - php: 7.1
-      env:
-        - GUZZLE_VERSION=^5.3
-        - LARAVEL_VERSION=5.5.*
+      dist: bionic
+      env: LARAVEL_VERSION=5.3.*
     - php: 7.1
-      env:
-        - GUZZLE_VERSION=^6.0
-        - LARAVEL_VERSION=5.5.*
+      dist: bionic
+      env: LARAVEL_VERSION=5.4.*
     - php: 7.1
-      env:
-        - GUZZLE_VERSION=^5.3
-        - LARAVEL_VERSION=5.6.*
+      dist: bionic
+      env: LARAVEL_VERSION=5.5.*
     - php: 7.1
-      env:
-        - GUZZLE_VERSION=^6.0
-        - LARAVEL_VERSION=5.6.*
+      dist: bionic
+      env: LARAVEL_VERSION=5.6.*
     - php: 7.1
-      env:
-        - GUZZLE_VERSION=^5.3
-        - LARAVEL_VERSION=5.8.*
+      dist: bionic
+      env: LARAVEL_VERSION=5.7.*
     - php: 7.1
-      env:
-        - GUZZLE_VERSION=^6.0
-        - LARAVEL_VERSION=5.8.*
+      dist: bionic
+      env: LARAVEL_VERSION=5.8.*
     - php: 7.2
-      env:
-        - GUZZLE_VERSION=^5.3
-        - LARAVEL_VERSION=5.5.*
+      dist: bionic
+      env: LARAVEL_VERSION=5.5.*
     - php: 7.2
-      env:
-        - GUZZLE_VERSION=^6.0
-        - LARAVEL_VERSION=5.5.*
+      dist: bionic
+      env: LARAVEL_VERSION=5.6.*
     - php: 7.2
-      env:
-        - GUZZLE_VERSION=^5.3
-        - LARAVEL_VERSION=5.6.*
+      dist: bionic
+      env: LARAVEL_VERSION=5.7.*
     - php: 7.2
-      env:
-        - GUZZLE_VERSION=^6.0
-        - LARAVEL_VERSION=5.6.*
+      dist: bionic
+      env: LARAVEL_VERSION=5.8.*
     - php: 7.2
-      env:
-        - GUZZLE_VERSION=^5.3
-        - LARAVEL_VERSION=5.8.*
+      dist: bionic
+      env: LARAVEL_VERSION=6.*
     - php: 7.2
-      env:
-        - GUZZLE_VERSION=^6.0
-        - LARAVEL_VERSION=5.8.*
+      dist: bionic
+      env: LARAVEL_VERSION=7.*
     - php: 7.3
-      env:
-        - GUZZLE_VERSION=^5.3
-        - LARAVEL_VERSION=5.8.*
+      dist: bionic
+      env: LARAVEL_VERSION=5.5.*
     - php: 7.3
-      env:
-        - GUZZLE_VERSION=^6.0
-        - LARAVEL_VERSION=5.8.*
-    - php: hhvm-3.6
-      sudo: required
-      dist: trusty
-      group: edge
-      env:
-        - GUZZLE_VERSION=^5.3
-        - LARAVEL_VERSION=5.1.*
-    - php: hhvm-3.6
-      sudo: required
-      dist: trusty
-      group: edge
-      env:
-        - GUZZLE_VERSION=^6.0
-        - LARAVEL_VERSION=5.1.*
-    - php: hhvm-3.9
-      sudo: required
-      dist: trusty
-      group: edge
-      env:
-        - GUZZLE_VERSION=^5.3
-        - LARAVEL_VERSION=5.1.*
-    - php: hhvm-3.9
-      sudo: required
-      dist: trusty
-      group: edge
-      env:
-        - GUZZLE_VERSION=^6.0
-        - LARAVEL_VERSION=5.1.*
-    - php: hhvm-3.12
-      sudo: required
-      dist: trusty
-      group: edge
-      env:
-        - GUZZLE_VERSION=^5.3
-        - LARAVEL_VERSION=5.1.*
-    - php: hhvm-3.12
-      sudo: required
-      dist: trusty
-      group: edge
-      env:
-        - GUZZLE_VERSION=^6.0
-        - LARAVEL_VERSION=5.1.*
+      dist: bionic
+      env: LARAVEL_VERSION=5.6.*
+    - php: 7.3
+      dist: bionic
+      env: LARAVEL_VERSION=5.7.*
+    - php: 7.3
+      dist: bionic
+      env: LARAVEL_VERSION=5.8.*
+    - php: 7.3
+      dist: bionic
+      env: LARAVEL_VERSION=6.*
+    - php: 7.3
+      dist: bionic
+      env: LARAVEL_VERSION=7.*
+    - php: 7.4
+      dist: bionic
+      env: LARAVEL_VERSION=5.8.*
+    - php: 7.4
+      dist: bionic
+      env: LARAVEL_VERSION=6.*
+    - php: 7.4
+      dist: bionic
+      env: LARAVEL_VERSION=7.*
     - addons:
         apt:
           packages:
@@ -179,8 +142,6 @@ matrix:
         - LARAVEL_FIXTURE=laravel66
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then echo 'hhvm.jit = false' >> /etc/hhvm/php.ini ; fi
-  - composer require "guzzlehttp/guzzle:${GUZZLE_VERSION}" --no-update
   - composer require "laravel/framework:${LARAVEL_VERSION}" --no-update
   - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     ],
     "require": {
         "php": ">=5.5",
+        "bugsnag/bugsnag": "^3.20",
+        "bugsnag/bugsnag-psr-logger": "^1.4",
         "illuminate/contracts": "^5.0|^6.0|^7.0",
         "illuminate/support": "^5.0|^6.0|^7.0",
-        "bugsnag/bugsnag": "^3.17.0",
-        "bugsnag/bugsnag-psr-logger": "^1.4",
         "monolog/monolog": "^1.12|^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
     ],
     "require": {
         "php": ">=5.5",
-        "illuminate/contracts": "^5.0|^6.0",
-        "illuminate/support": "^5.0|^6.0",
+        "illuminate/contracts": "^5.0|^6.0|^7.0",
+        "illuminate/support": "^5.0|^6.0|^7.0",
         "bugsnag/bugsnag": "^3.17.0",
         "bugsnag/bugsnag-psr-logger": "^1.4",
         "monolog/monolog": "^1.12|^2.0"
     },
     "require-dev": {
         "graham-campbell/testbench": "^3.1|^4.0|^5.0",
-        "mockery/mockery": "^0.9.4|~1.1.0",
-        "phpunit/phpunit": "^4.8|^5.0|^6.0|^7.0"
+        "mockery/mockery": "^0.9.4|^1.3.1",
+        "phpunit/phpunit": "^4.8.36|^5.6.3|^6.3.1|^7.5.15|^8.3.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Closes https://github.com/bugsnag/bugsnag-laravel/issues/386. Also drops HHVM in line with the main PHP notifier dropping it.