### PR TITLE
Add new options for passing regexes to project root and strip path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## TBD
+
+* Add new options for using regexes to match the project root and strip path
+  [#398](https://github.com/bugsnag/bugsnag-laravel/pull/398)
+
 ## 2.18.0 (2020-02-26)
 
 ### Enhancements

--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -129,9 +129,8 @@ return [
     | Bugsnag marks stacktrace lines as in-project if they come from files
     | inside your “project root”. You can set this here.
     |
-    | If this is not set, we will automatically try to detect it.
-    |
-    | Do not fill strip_path neither project_path using this option
+    | This option allows you to set it as a regular expression and will take
+    | precedence over "project_root" if both are defined.
     |
     */
 
@@ -142,8 +141,8 @@ return [
     | Strip Path
     |--------------------------------------------------------------------------
     |
-    | You can set a strip path to have it also trimmed from the start of any
-    | filepath in your stacktraces.
+    | The strip path is a path to be trimmed from the start of any filepaths in
+    | your stacktraces.
     |
     | If this is not set, we will automatically try to detect it.
     |
@@ -156,12 +155,11 @@ return [
     | Strip Path Regex
     |--------------------------------------------------------------------------
     |
-    | You can set a strip path regular expression to have it also trimmed from the start of any
-    | filepath in your stacktraces.
+    | The strip path is a path to be trimmed from the start of any filepaths in
+    | your stacktraces.
     |
-    | If this is not set, we will automatically try to detect it.
-    |
-    | Do not fill strip_path neither project_path using this option
+    | This option allows you to set it as a regular expression and will take
+    | precedence over "strip_path" if both are defined.
     |
     */
 

--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -123,6 +123,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Project Root Regex
+    |--------------------------------------------------------------------------
+    |
+    | Bugsnag marks stacktrace lines as in-project if they come from files
+    | inside your “project root”. You can set this here.
+    |
+    | If this is not set, we will automatically try to detect it.
+    |
+    | Do not fill strip_path neither project_path using this option
+    |
+    */
+
+    'project_root_regex' => env('BUGSNAG_PROJECT_ROOT_REGEX'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Strip Path
     |--------------------------------------------------------------------------
     |
@@ -134,6 +150,22 @@ return [
     */
 
     'strip_path' => env('BUGSNAG_STRIP_PATH'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Strip Path Regex
+    |--------------------------------------------------------------------------
+    |
+    | You can set a strip path regular expression to have it also trimmed from the start of any
+    | filepath in your stacktraces.
+    |
+    | If this is not set, we will automatically try to detect it.
+    |
+    | Do not fill strip_path neither project_path using this option
+    |
+    */
+
+    'strip_path_regex' => env('BUGSNAG_STRIP_PATH_REGEX'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -343,36 +343,23 @@ class BugsnagServiceProvider extends ServiceProvider
         $stripRegex = $config['strip_path_regex'] ?? null;
         $projectRegex = $config['project_root_regex'] ?? null;
 
-        if ($strip) {
-            if (!$project) {
-                $client->setProjectRoot("{$strip}/app");
-            }
-
-            $client->setStripPath($strip);
-
-            return;
-        }
+        $client->setProjectRoot($projectDefault);
+        $client->setStripPath($stripDefault);
 
         if ($project) {
             $client->setProjectRoot($project);
-
-            if ($stripDefault && substr($project, 0, strlen($stripDefault)) === $stripDefault) {
-                $client->setStripPath($stripDefault);
-            }
-
-            return;
         }
 
-        if (isset($stripRegex)) {
-            $client->setStripPathRegex($stripRegex);
-        } else {
-            $client->setStripPath($stripDefault);
+        if ($strip) {
+            $client->setStripPath($strip);
         }
 
-        if (isset($projectRegex)) {
+        if ($projectRegex) {
             $client->setProjectRootRegex($projectRegex);
-        } else {
-            $client->setProjectRoot($projectDefault);
+        }
+
+        if ($stripRegex) {
+            $client->setStripPathRegex($stripRegex);
         }
     }
 

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -336,41 +336,20 @@ class BugsnagServiceProvider extends ServiceProvider
      */
     protected function setupPaths(Client $client, Container $app, array $config)
     {
-        $basePath = $app->basePath();
-
-        if (isset($config['strip_path']) && !isset($config['strip_path_regex'])) {
-            $client->setStripPath($config['strip_path']);
-
-            // TODO this may be a bug
-            if (!isset($config['project_root']) && !isset($config['project_root_regex'])) {
-                $client->setProjectRoot($config['strip_path'].'/app');
-            }
-
-            // Stop here to prevent changing the project root we just set
-            return;
-        } else {
-            $client->setStripPath($basePath);
-        }
-
-        if (isset($config['project_root_regex'])) {
+        if (isset($config['project_root_regex']) && $config['project_root_regex'] !== '') {
             $client->setProjectRootRegex($config['project_root_regex']);
-        } elseif (isset($config['project_root'])) {
-            // TODO this may be a bug
-            if (!isset($config['strip_path_regex'])
-                && !isset($config['strip_path'])
-                && $basePath
-                && substr($config['project_root'], 0, strlen($basePath)) === $basePath
-            ) {
-                $client->setStripPath($basePath);
-            }
-
+        } elseif (isset($config['project_root']) && $config['project_root'] !== '') {
             $client->setProjectRoot($config['project_root']);
-        } elseif (!isset($config['strip_path_regex'])) {
+        } else {
             $client->setProjectRoot($app->path());
         }
 
-        if (isset($config['strip_path_regex'])) {
+        if (isset($config['strip_path_regex']) && $config['strip_path_regex'] !== '') {
             $client->setStripPathRegex($config['strip_path_regex']);
+        } elseif (isset($config['strip_path']) && $config['strip_path'] !== '') {
+            $client->setStripPath($config['strip_path']);
+        } else {
+            $client->setStripPath($app->basePath());
         }
     }
 

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -344,11 +344,11 @@ class BugsnagServiceProvider extends ServiceProvider
         $projectRegex = $config['project_root_regex'] ?? null;
 
         if ($strip) {
-            $client->setStripPath($strip);
-
             if (!$project) {
                 $client->setProjectRoot("{$strip}/app");
             }
+
+            $client->setStripPath($strip);
 
             return;
         }

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -336,17 +336,17 @@ class BugsnagServiceProvider extends ServiceProvider
      */
     protected function setupPaths(Client $client, Container $app, array $config)
     {
-        if (isset($config['project_root_regex']) && $config['project_root_regex'] !== '') {
+        if (isset($config['project_root_regex'])) {
             $client->setProjectRootRegex($config['project_root_regex']);
-        } elseif (isset($config['project_root']) && $config['project_root'] !== '') {
+        } elseif (isset($config['project_root'])) {
             $client->setProjectRoot($config['project_root']);
         } else {
             $client->setProjectRoot($app->path());
         }
 
-        if (isset($config['strip_path_regex']) && $config['strip_path_regex'] !== '') {
+        if (isset($config['strip_path_regex'])) {
             $client->setStripPathRegex($config['strip_path_regex']);
-        } elseif (isset($config['strip_path']) && $config['strip_path'] !== '') {
+        } elseif (isset($config['strip_path'])) {
             $client->setStripPath($config['strip_path']);
         } else {
             $client->setStripPath($app->basePath());

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -336,30 +336,41 @@ class BugsnagServiceProvider extends ServiceProvider
      */
     protected function setupPaths(Client $client, Container $app, array $config)
     {
-        $stripDefault = $app->basePath();
-        $projectDefault = $app->path();
-        $strip = isset($config['strip_path']) ? $config['strip_path'] : null;
-        $project = isset($config['project_root']) ? $config['project_root'] : null;
-        $stripRegex = isset($config['strip_path_regex']) ? $config['strip_path_regex'] : null;
-        $projectRegex = isset($config['project_root_regex']) ? $config['project_root_regex'] : null;
+        $basePath = $app->basePath();
 
-        $client->setProjectRoot($projectDefault);
-        $client->setStripPath($stripDefault);
+        if (isset($config['strip_path']) && !isset($config['strip_path_regex'])) {
+            $client->setStripPath($config['strip_path']);
 
-        if ($project) {
-            $client->setProjectRoot($project);
+            // TODO this may be a bug
+            if (!isset($config['project_root']) && !isset($config['project_root_regex'])) {
+                $client->setProjectRoot($config['strip_path'] . '/app');
+            }
+
+            // Stop here to prevent changing the project root we just set
+            return;
+        } else {
+            $client->setStripPath($basePath);
         }
 
-        if ($strip) {
-            $client->setStripPath($strip);
+        if (isset($config['project_root_regex'])) {
+            $client->setProjectRootRegex($config['project_root_regex']);
+        } elseif (isset($config['project_root'])) {
+            // TODO this may be a bug
+            if (!isset($config['strip_path_regex'])
+                && !isset($config['strip_path'])
+                && $basePath
+                && substr($config['project_root'], 0, strlen($basePath)) === $basePath
+            ) {
+                $client->setStripPath($basePath);
+            }
+
+            $client->setProjectRoot($config['project_root']);
+        } elseif (!isset($config['strip_path_regex'])) {
+            $client->setProjectRoot($app->path());
         }
 
-        if ($projectRegex) {
-            $client->setProjectRootRegex($projectRegex);
-        }
-
-        if ($stripRegex) {
-            $client->setStripPathRegex($stripRegex);
+        if (isset($config['strip_path_regex'])) {
+            $client->setStripPathRegex($config['strip_path_regex']);
         }
     }
 

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -358,13 +358,13 @@ class BugsnagServiceProvider extends ServiceProvider
             return;
         }
 
-        if(isset($stripRegex)) {
+        if (isset($stripRegex)) {
             $client->setStripPathRegex($stripRegex);
         } else {
             $client->setStripPath($base);
         }
 
-        if(isset($projectRegex)) {
+        if (isset($projectRegex)) {
             $client->setProjectRootRegex($projectRegex);
         } else {
             $client->setProjectRoot($path);

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -186,7 +186,7 @@ class BugsnagServiceProvider extends ServiceProvider
             $client = new Client(new Configuration($config['api_key']), new LaravelResolver($app), $this->getGuzzle($config));
 
             $this->setupCallbacks($client, $app, $config);
-            $this->setupPaths($client, $app->basePath(), $app->path(), isset($config['strip_path']) ? $config['strip_path'] : null, isset($config['project_root']) ? $config['project_root'] : null);
+            $this->setupPaths($client, $app->basePath(), $app->path(), isset($config['strip_path']) ? $config['strip_path'] : null, isset($config['project_root']) ? $config['project_root'] : null, isset($config['strip_path_regex']) ? $config['strip_path_regex'] : null, isset($config['project_root_regex']) ? $config['project_root_regex'] : null);
 
             $client->setReleaseStage(isset($config['release_stage']) ? $config['release_stage'] : $app->environment());
             $client->setHostname(isset($config['hostname']) ? $config['hostname'] : null);
@@ -336,7 +336,7 @@ class BugsnagServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function setupPaths(Client $client, $base, $path, $strip, $project)
+    protected function setupPaths(Client $client, $base, $path, $strip, $project, $stripRegex, $projectRegex)
     {
         if ($strip) {
             $client->setStripPath($strip);
@@ -358,8 +358,17 @@ class BugsnagServiceProvider extends ServiceProvider
             return;
         }
 
-        $client->setStripPath($base);
-        $client->setProjectRoot($path);
+        if(isset($stripRegex)) {
+            $client->setStripPathRegex($stripRegex);
+        } else {
+            $client->setStripPath($base);
+        }
+
+        if(isset($projectRegex)) {
+            $client->setProjectRootRegex($projectRegex);
+        } else {
+            $client->setProjectRoot($path);
+        }
     }
 
     /**

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -338,10 +338,10 @@ class BugsnagServiceProvider extends ServiceProvider
     {
         $stripDefault = $app->basePath();
         $projectDefault = $app->path();
-        $strip = $config['strip_path'] ?? null;
-        $project = $config['project_root'] ?? null;
-        $stripRegex = $config['strip_path_regex'] ?? null;
-        $projectRegex = $config['project_root_regex'] ?? null;
+        $strip = isset($config['strip_path']) ? $config['strip_path'] : null;
+        $project = isset($config['project_root']) ? $config['project_root'] : null;
+        $stripRegex = isset($config['strip_path_regex']) ? $config['strip_path_regex'] : null;
+        $projectRegex = isset($config['project_root_regex']) ? $config['project_root_regex'] : null;
 
         $client->setProjectRoot($projectDefault);
         $client->setStripPath($stripDefault);

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -354,11 +354,11 @@ class BugsnagServiceProvider extends ServiceProvider
         }
 
         if ($project) {
+            $client->setProjectRoot($project);
+
             if ($stripDefault && substr($project, 0, strlen($stripDefault)) === $stripDefault) {
                 $client->setStripPath($stripDefault);
             }
-
-            $client->setProjectRoot($project);
 
             return;
         }

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -343,7 +343,7 @@ class BugsnagServiceProvider extends ServiceProvider
 
             // TODO this may be a bug
             if (!isset($config['project_root']) && !isset($config['project_root_regex'])) {
-                $client->setProjectRoot($config['strip_path'] . '/app');
+                $client->setProjectRoot($config['strip_path'].'/app');
             }
 
             // Stop here to prevent changing the project root we just set

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -159,7 +159,7 @@ class ServiceProviderTest extends AbstractTestCase
         return [
             // If both strings are provided, both options should be set to the
             // regex version of the given strings
-            'both strings provided (regexes null)' => [
+            'both strings provided' => [
                 'project_root' => '/example/project/root',
                 'strip_path' => '/example/strip/path',
                 'project_root_regex' => null,
@@ -168,31 +168,10 @@ class ServiceProviderTest extends AbstractTestCase
                 'expected_strip_path_regex' => $this->pathToRegex('/example/strip/path'),
             ],
 
-            // If both strings are provided, both options should be set to the
-            // regex version of the given strings
-            'both strings provided (regexes empty string)' => [
-                'project_root' => '/example/project/root',
-                'strip_path' => '/example/strip/path',
-                'project_root_regex' => '',
-                'strip_path_regex' => '',
-                'expected_project_root_regex' => $this->pathToRegex('/example/project/root'),
-                'expected_strip_path_regex' => $this->pathToRegex('/example/strip/path'),
-            ],
-
             // If both regexes are provided they should be set verbatim
-            'both regexes provided (strings null)' => [
+            'both regexes provided' => [
                 'project_root' => null,
                 'strip_path' => null,
-                'project_root_regex' => '/^example project root regex/',
-                'strip_path_regex' => '/^example strip path regex/',
-                'expected_project_root_regex' => '/^example project root regex/',
-                'expected_strip_path_regex' => '/^example strip path regex/',
-            ],
-
-            // If both regexes are provided they should be set verbatim
-            'both regexes provided (strings empty string)' => [
-                'project_root' => '',
-                'strip_path' => '',
                 'project_root_regex' => '/^example project root regex/',
                 'strip_path_regex' => '/^example strip path regex/',
                 'expected_project_root_regex' => '/^example project root regex/',

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -141,29 +141,29 @@ class ServiceProviderTest extends AbstractTestCase
     public function projectRootAndStripPathProvider()
     {
         return [
-            // If both parameters are provided, the project root should be null
+            // If both strings are provided, the project root should be null
             // and the strip path set to a regex matching the given string
             // TODO this might be a bug — when a strip path value is configured,
             //      we only set the project root path if one wasn't provided. If both
             //      strip path _and_ project root are given, no project root is set
-            'both provided' => [
+            'both strings provided' => [
                 'project_root' => '/example/project/root',
                 'strip_path' => '/example/strip/path',
                 'expected_project_root_regex' => null,
                 'expected_strip_path_regex' => $this->pathToRegex('/example/strip/path'),
             ],
 
-            // If only the project root is provided, both values should be set to
-            // the same regex matching the given project root string
-            'only project root provided' => [
+            // If only the project root string is provided, both values should be
+            // set to the same regex matching the given project root string
+            'only project root string provided' => [
                 'project_root' => '/example/project/root',
                 'strip_path' => null,
                 'expected_project_root_regex' => $this->pathToRegex('/example/project/root'),
                 'expected_strip_path_regex' => $this->pathToRegex('/example/project/root'),
             ],
 
-            // If only the strip path is provided, both values should be set to
-            // the same regex matching the given strip path string with "/app"
+            // If only the strip path string is provided, both values should be
+            // set to the same regex matching the given strip path string with "/app"
             // appended
             // TODO this might be a bug — when only strip path is configured,
             //      we set the strip path and then immediately overwrite it with
@@ -171,7 +171,7 @@ class ServiceProviderTest extends AbstractTestCase
             //      If the intention is to to have "/example" be the strip path
             //      and "/example/app" be the project root then we need to do these
             //      calls in the opposite order
-            'only strip path provided' => [
+            'only strip path string provided' => [
                 'project_root' => null,
                 'strip_path' => '/example/strip/path',
                 'expected_project_root_regex' => $this->pathToRegex('/example/strip/path/app'),

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -57,7 +57,6 @@ class ServiceProviderTest extends AbstractTestCase
 
         $this->assertInstanceOf(Client::class, $client);
 
-        $basePath = $this->app->basePath();
         $appRoot = $this->app->path();
 
         /** @var Client $client */
@@ -116,7 +115,6 @@ class ServiceProviderTest extends AbstractTestCase
 
         $this->assertInstanceOf(Client::class, $client);
 
-        $basePath = $this->app->basePath();
         $appRoot = $this->app->path();
 
         /** @var Client $client */

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -83,6 +83,8 @@ class ServiceProviderTest extends AbstractTestCase
     /**
      * @param string|null $projectRoot
      * @param string|null $stripPath
+     * @param string|null $projectRootRegex
+     * @param string|null $stripPathRegex
      * @param string|null $expectedProjectRootRegex
      * @param string      $expectedStripPathRegex
      *
@@ -90,8 +92,14 @@ class ServiceProviderTest extends AbstractTestCase
      *
      * @dataProvider projectRootAndStripPathProvider
      */
-    public function testProjectRootAndStripPathAreSetCorrectly($projectRoot, $stripPath, $expectedProjectRootRegex, $expectedStripPathRegex)
-    {
+    public function testProjectRootAndStripPathAreSetCorrectly(
+        $projectRoot,
+        $stripPath,
+        $projectRootRegex,
+        $stripPathRegex,
+        $expectedProjectRootRegex,
+        $expectedStripPathRegex
+    ) {
         /** @var \Illuminate\Config\Repository $laravelConfig */
         $laravelConfig = $this->app->config;
         $bugsnagConfig = $laravelConfig->get('bugsnag');
@@ -106,8 +114,20 @@ class ServiceProviderTest extends AbstractTestCase
             "Expected the default configuration value for 'strip_path' to be null"
         );
 
+        $this->assertNull(
+            $bugsnagConfig['project_root_regex'],
+            "Expected the default configuration value for 'project_root_regex' to be null"
+        );
+
+        $this->assertNull(
+            $bugsnagConfig['strip_path_regex'],
+            "Expected the default configuration value for 'strip_path_regex' to be null"
+        );
+
         $bugsnagConfig['project_root'] = $projectRoot;
         $bugsnagConfig['strip_path'] = $stripPath;
+        $bugsnagConfig['project_root_regex'] = $projectRootRegex;
+        $bugsnagConfig['strip_path_regex'] = $stripPathRegex;
 
         $laravelConfig->set('bugsnag', $bugsnagConfig);
 
@@ -147,6 +167,8 @@ class ServiceProviderTest extends AbstractTestCase
             'both strings provided' => [
                 'project_root' => '/example/project/root',
                 'strip_path' => '/example/strip/path',
+                'project_root_regex' => null,
+                'strip_path_regex' => null,
                 'expected_project_root_regex' => null,
                 'expected_strip_path_regex' => $this->pathToRegex('/example/strip/path'),
             ],
@@ -156,6 +178,8 @@ class ServiceProviderTest extends AbstractTestCase
             'only project root string provided' => [
                 'project_root' => '/example/project/root',
                 'strip_path' => null,
+                'project_root_regex' => null,
+                'strip_path_regex' => null,
                 'expected_project_root_regex' => $this->pathToRegex('/example/project/root'),
                 'expected_strip_path_regex' => $this->pathToRegex('/example/project/root'),
             ],
@@ -172,6 +196,8 @@ class ServiceProviderTest extends AbstractTestCase
             'only strip path string provided' => [
                 'project_root' => null,
                 'strip_path' => '/example/strip/path',
+                'project_root_regex' => null,
+                'strip_path_regex' => null,
                 'expected_project_root_regex' => $this->pathToRegex('/example/strip/path/app'),
                 'expected_strip_path_regex' => $this->pathToRegex('/example/strip/path/app'),
             ],

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -144,15 +144,15 @@ class ServiceProviderTest extends AbstractTestCase
         $stripPathRegex = $this->getProperty($config, 'stripPathRegex');
 
         $this->assertSame(
-            $expectedStripPathRegex,
-            $stripPathRegex,
-            "Expected the 'stripPathRegex' to match the string provided in Bugsnag configuration"
-        );
-
-        $this->assertSame(
             $expectedProjectRootRegex,
             $projectRootRegex,
             "Expected the 'projectRootRegex' to match the string provided in Bugsnag configuration"
+        );
+
+        $this->assertSame(
+            $expectedStripPathRegex,
+            $stripPathRegex,
+            "Expected the 'stripPathRegex' to match the string provided in Bugsnag configuration"
         );
     }
 
@@ -173,6 +173,17 @@ class ServiceProviderTest extends AbstractTestCase
                 'expected_strip_path_regex' => $this->pathToRegex('/example/strip/path'),
             ],
 
+            // If both regexes are provided they should be set on the configuration
+            // object verbatim
+            'both regexes provided' => [
+                'project_root' => null,
+                'strip_path' => null,
+                'project_root_regex' => '/^example project root regex/',
+                'strip_path_regex' => '/^example strip path regex/',
+                'expected_project_root_regex' => '/^example project root regex/',
+                'expected_strip_path_regex' => '/^example strip path regex/',
+            ],
+
             // If only the project root string is provided, both values should be
             // set to the same regex matching the given project root string
             'only project root string provided' => [
@@ -182,6 +193,17 @@ class ServiceProviderTest extends AbstractTestCase
                 'strip_path_regex' => null,
                 'expected_project_root_regex' => $this->pathToRegex('/example/project/root'),
                 'expected_strip_path_regex' => $this->pathToRegex('/example/project/root'),
+            ],
+
+            // If only the project root regex is provided, both values should be
+            // set to the same regex
+            'only project root regex provided' => [
+                'project_root' => null,
+                'strip_path' => null,
+                'project_root_regex' => '/^example project root regex/',
+                'strip_path_regex' => null,
+                'expected_project_root_regex' => '/^example project root regex/',
+                'expected_strip_path_regex' => '/^example project root regex/',
             ],
 
             // If only the strip path string is provided, both values should be
@@ -200,6 +222,59 @@ class ServiceProviderTest extends AbstractTestCase
                 'strip_path_regex' => null,
                 'expected_project_root_regex' => $this->pathToRegex('/example/strip/path/app'),
                 'expected_strip_path_regex' => $this->pathToRegex('/example/strip/path/app'),
+            ],
+
+            // If only the strip path regex is provided, the strip path should be
+            // set verbatim and the project root should not be set
+            // TODO is this the correct behaviour? In the \Bugsnag\Configuration
+            //      class we set the strip path when setting the project root but
+            //      we don't set the project root when setting the strip path so
+            //      this test makes sense in that context. However we try to guess
+            //      the project root based on the strip path when strings are
+            //      provided so should be do that here too?
+            'only strip path regex provided' => [
+                'project_root' => null,
+                'strip_path' => null,
+                'project_root_regex' => null,
+                'strip_path_regex' => '/^example strip path regex/',
+                'expected_project_root_regex' => null,
+                'expected_strip_path_regex' => '/^example strip path regex/',
+            ],
+
+            // If the regexes are provided and either string value is too then
+            // the regexes should take precedence and the string value ignored
+            // TODO should this throw an exception instead?
+            'project root string and both regexes provided' => [
+                'project_root' => $this->pathToRegex('/example/project/root'),
+                'strip_path' => null,
+                'project_root_regex' => '/^example project root regex/',
+                'strip_path_regex' => '/^example strip path regex/',
+                'expected_project_root_regex' => '/^example project root regex/',
+                'expected_strip_path_regex' => '/^example strip path regex/',
+            ],
+
+            // If the regexes are provided and either string value is too then
+            // the regexes should take precedence and the string value ignored
+            // TODO should this throw an exception instead?
+            'strip path string and both regexes provided' => [
+                'project_root' => null,
+                'strip_path' => $this->pathToRegex('/example/strip/path'),
+                'project_root_regex' => '/^example project root regex/',
+                'strip_path_regex' => '/^example strip path regex/',
+                'expected_project_root_regex' => '/^example project root regex/',
+                'expected_strip_path_regex' => '/^example strip path regex/',
+            ],
+
+            // If all four options are provided then the regexes should take
+            // precedence and the string values ignored
+            // TODO should this throw an exception instead?
+            'all options provided' => [
+                'project_root' => $this->pathToRegex('/example/project/root'),
+                'strip_path' => $this->pathToRegex('/example/strip/path'),
+                'project_root_regex' => '/^example project root regex/',
+                'strip_path_regex' => '/^example strip path regex/',
+                'expected_project_root_regex' => '/^example project root regex/',
+                'expected_strip_path_regex' => '/^example strip path regex/',
             ],
         ];
     }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -57,16 +57,14 @@ class ServiceProviderTest extends AbstractTestCase
 
         $this->assertInstanceOf(Client::class, $client);
 
-        $appRoot = $this->app->path();
-
         /** @var Client $client */
         $config = $client->getConfig();
 
         $projectRootRegex = $this->getProperty($config, 'projectRootRegex');
         $stripPathRegex = $this->getProperty($config, 'stripPathRegex');
 
-        $expectedProjectRootRegex = sprintf('/^%s[\\/]?/i', preg_quote($appRoot, '/'));
-        $expectedStripPathRegex = $expectedProjectRootRegex;
+        $expectedProjectRootRegex = $this->pathToRegex($this->app->path());
+        $expectedStripPathRegex = $this->pathToRegex($this->app->basePath());
 
         $this->assertSame(
             $expectedStripPathRegex,
@@ -159,23 +157,30 @@ class ServiceProviderTest extends AbstractTestCase
     public function projectRootAndStripPathProvider()
     {
         return [
-            // If both strings are provided, the project root should be null
-            // and the strip path set to a regex matching the given string
-            // TODO this might be a bug — when a strip path value is configured,
-            //      we only set the project root path if one wasn't provided. If both
-            //      strip path _and_ project root are given, no project root is set
-            'both strings provided' => [
+            // If both strings are provided, both options should be set to the
+            // regex version of the given strings
+            'both strings provided (regexes null)' => [
                 'project_root' => '/example/project/root',
                 'strip_path' => '/example/strip/path',
                 'project_root_regex' => null,
                 'strip_path_regex' => null,
-                'expected_project_root_regex' => null,
+                'expected_project_root_regex' => $this->pathToRegex('/example/project/root'),
                 'expected_strip_path_regex' => $this->pathToRegex('/example/strip/path'),
             ],
 
-            // If both regexes are provided they should be set on the configuration
-            // object verbatim
-            'both regexes provided' => [
+            // If both strings are provided, both options should be set to the
+            // regex version of the given strings
+            'both strings provided (regexes empty string)' => [
+                'project_root' => '/example/project/root',
+                'strip_path' => '/example/strip/path',
+                'project_root_regex' => '',
+                'strip_path_regex' => '',
+                'expected_project_root_regex' => $this->pathToRegex('/example/project/root'),
+                'expected_strip_path_regex' => $this->pathToRegex('/example/strip/path'),
+            ],
+
+            // If both regexes are provided they should be set verbatim
+            'both regexes provided (strings null)' => [
                 'project_root' => null,
                 'strip_path' => null,
                 'project_root_regex' => '/^example project root regex/',
@@ -184,15 +189,26 @@ class ServiceProviderTest extends AbstractTestCase
                 'expected_strip_path_regex' => '/^example strip path regex/',
             ],
 
-            // If only the project root string is provided, both values should be
-            // set to the same regex matching the given project root string
+            // If both regexes are provided they should be set verbatim
+            'both regexes provided (strings empty string)' => [
+                'project_root' => '',
+                'strip_path' => '',
+                'project_root_regex' => '/^example project root regex/',
+                'strip_path_regex' => '/^example strip path regex/',
+                'expected_project_root_regex' => '/^example project root regex/',
+                'expected_strip_path_regex' => '/^example strip path regex/',
+            ],
+
+            // If only the project root string is provided, the project root should
+            // be set to the regex version of the string and the strip path to
+            // the application base path
             'only project root string provided' => [
                 'project_root' => '/example/project/root',
                 'strip_path' => null,
                 'project_root_regex' => null,
                 'strip_path_regex' => null,
                 'expected_project_root_regex' => $this->pathToRegex('/example/project/root'),
-                'expected_strip_path_regex' => $this->pathToRegex('/example/project/root'),
+                'expected_strip_path_regex' => $this->pathToRegex($this->getBasePath()),
             ],
 
             // If only the project root regex is provided, both values should be
@@ -203,47 +219,35 @@ class ServiceProviderTest extends AbstractTestCase
                 'project_root_regex' => '/^example project root regex/',
                 'strip_path_regex' => null,
                 'expected_project_root_regex' => '/^example project root regex/',
-                'expected_strip_path_regex' => '/^example project root regex/',
+                'expected_strip_path_regex' => $this->pathToRegex($this->getBasePath()),
             ],
 
             // If only the strip path string is provided, both values should be
-            // set to the same regex matching the given strip path string with "/app"
-            // appended
-            // TODO this might be a bug — when only strip path is configured,
-            //      we set the strip path and then immediately overwrite it with
-            //      a new path with "/app" appended by calling `setProjectRoot`.
-            //      If the intention is to to have "/example" be the strip path
-            //      and "/example/app" be the project root then we need to do these
-            //      calls in the opposite order
+            // set — the stip path to the regex version of the string and the
+            // project root with "/app" appended
             'only strip path string provided' => [
                 'project_root' => null,
                 'strip_path' => '/example/strip/path',
                 'project_root_regex' => null,
                 'strip_path_regex' => null,
-                'expected_project_root_regex' => $this->pathToRegex('/example/strip/path/app'),
-                'expected_strip_path_regex' => $this->pathToRegex('/example/strip/path/app'),
+                'expected_project_root_regex' => $this->pathToRegex("{$this->getBasePath()}/app"),
+                'expected_strip_path_regex' => $this->pathToRegex('/example/strip/path'),
             ],
 
             // If only the strip path regex is provided, the strip path should be
-            // set verbatim and the project root should not be set
-            // TODO is this the correct behaviour? In the \Bugsnag\Configuration
-            //      class we set the strip path when setting the project root but
-            //      we don't set the project root when setting the strip path so
-            //      this test makes sense in that context. However we try to guess
-            //      the project root based on the strip path when strings are
-            //      provided so should be do that here too?
+            // set verbatim and the project root should be set to the application
+            // path (i.e. "/base/path/app")
             'only strip path regex provided' => [
                 'project_root' => null,
                 'strip_path' => null,
                 'project_root_regex' => null,
                 'strip_path_regex' => '/^example strip path regex/',
-                'expected_project_root_regex' => null,
+                'expected_project_root_regex' => $this->pathToRegex("{$this->getBasePath()}/app"),
                 'expected_strip_path_regex' => '/^example strip path regex/',
             ],
 
             // If the regexes are provided and either string value is too then
             // the regexes should take precedence and the string value ignored
-            // TODO should this throw an exception instead?
             'project root string and both regexes provided' => [
                 'project_root' => $this->pathToRegex('/example/project/root'),
                 'strip_path' => null,
@@ -255,7 +259,6 @@ class ServiceProviderTest extends AbstractTestCase
 
             // If the regexes are provided and either string value is too then
             // the regexes should take precedence and the string value ignored
-            // TODO should this throw an exception instead?
             'strip path string and both regexes provided' => [
                 'project_root' => null,
                 'strip_path' => $this->pathToRegex('/example/strip/path'),
@@ -267,7 +270,6 @@ class ServiceProviderTest extends AbstractTestCase
 
             // If all four options are provided then the regexes should take
             // precedence and the string values ignored
-            // TODO should this throw an exception instead?
             'all options provided' => [
                 'project_root' => $this->pathToRegex('/example/project/root'),
                 'strip_path' => $this->pathToRegex('/example/strip/path'),


### PR DESCRIPTION
## Goal

<!-- What is the intent of this change?
e.g. "When initializing the Bugsnag client, it is currently difficult to (...)
      this change simplifies the process by (...)"

     "Improves the performance of data filtering"

     "Adds additional test coverage to multi-threaded use of Configuration
      objects"
-->

Allow using the bugsnag-php options for setting the project root and strip path as regexes, rather than just strings

This adds two new options, `project_root_regex` and `strip_path_regex`, which can be used instead of the existing `project_root` and `strip_path` options to allow setting them as regexes, as introduced in https://github.com/bugsnag/bugsnag-php/pull/514

This is a continuation of https://github.com/bugsnag/bugsnag-laravel/pull/348

<!-- For new features, include design documentation:

## Design

Why was this approach to the goal used?

-->

## Changeset

<!-- What structures or properties or functions were: -->


### Added

- Two new configuration options:
    ```php
    'project_root_regex' => env('BUGSNAG_PROJECT_ROOT_REGEX'),
    'strip_path_regex' => env('BUGSNAG_STRIP_PATH_REGEX'),
    ```
    These take presendence over the existing `project_root` and `strip_path` options if they are also provided
- More tests for path resolution, building off of https://github.com/bugsnag/bugsnag-laravel/pull/395

### Changed

- Some of the existing path resolution code was leading to incorrect project root and strip path values being set, for example:
    - when a strip path value is configured, we only set the project root path if one wasn't provided. If both strip path _and_ project root are given, no project root is set
    - when only strip path is configured, we set the strip path and then immediately overwrite it with a new path with "/app" appended by calling `setProjectRoot`.
    These issues have been fixed in this branch

## Tests

<!-- How was this change tested? What manual and automated tests were
     run/added? -->

More unit tests have been added, building off of https://github.com/bugsnag/bugsnag-laravel/pull/395

## Discussion

### Alternative Approaches

<!-- What other approaches were considered or discussed? -->

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

### Linked issues

<!--

Fixes #
Related to #

-->

Related to bugsnag/bugsnag-php#514
Related to #348

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
