### PR TITLE
Add support for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "php": ">=5.5",
         "bugsnag/bugsnag": "^3.20",
         "bugsnag/bugsnag-psr-logger": "^1.4",
-        "illuminate/contracts": "^5.0|^6.0|^7.0",
-        "illuminate/support": "^5.0|^6.0|^7.0",
+        "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0",
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0",
         "monolog/monolog": "^1.12|^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds support for the upcoming Laravel 8 release (due 8 September) to the `composer.json` requirements.