### PR TITLE
Laravel 8 Support with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,9 @@ matrix:
     - php: 7.3
       dist: bionic
       env: LARAVEL_VERSION=7.*
+    - php: 7.3
+      dist: bionic
+      env: LARAVEL_VERSION=8.*
     - php: 7.4
       dist: bionic
       env: LARAVEL_VERSION=5.8.*
@@ -101,13 +104,16 @@ matrix:
     - php: 7.4
       dist: bionic
       env: LARAVEL_VERSION=7.*
+    - php: 7.4
+      dist: bionic
+      env: LARAVEL_VERSION=8.*
     - addons:
         apt:
           packages:
-          - docker-ce
+            - docker-ce
       sudo: required
       sevices:
-      - docker
+        - docker
       rvm: 2.4.1
       before_install: ruby --version
       install: bundle install
@@ -116,10 +122,10 @@ matrix:
     - addons:
         apt:
           packages:
-          - docker-ce
+            - docker-ce
       sudo: required
       sevices:
-      - docker
+        - docker
       rvm: 2.4.1
       before_install: ruby --version
       install: bundle install
@@ -128,10 +134,10 @@ matrix:
     - addons:
         apt:
           packages:
-          - docker-ce
+            - docker-ce
       sudo: required
       sevices:
-      - docker
+        - docker
       rvm: 2.4.1
       before_install: ruby --version
       install: bundle install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Allow installation on Laravel 8 projects
+  [jwpage](https://github.com/jwpage)
+  [jdavidbakr](https://github.com/jdavidbakr)
+  [#405](https://github.com/bugsnag/bugsnag-laravel/pull/405)
+  [#407](https://github.com/bugsnag/bugsnag-laravel/pull/407)
+
 ## 2.19.0 (2020-05-11)
 
 ### Enhancements

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "php": ">=5.5",
         "bugsnag/bugsnag": "^3.20",
         "bugsnag/bugsnag-psr-logger": "^1.4",
-        "illuminate/contracts": "^5.0|^6.0|^7.0",
-        "illuminate/support": "^5.0|^6.0|^7.0",
+        "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0",
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0",
         "monolog/monolog": "^1.12|^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Goal

Add support for Laravel 8

## Design

Added travis tests (extended from PR https://github.com/bugsnag/bugsnag-laravel/pull/405)

## Changeset

Tests added to Travis

## Testing

No additional tests were required