### PR TITLE
Use the default filters from Bugsnag PHP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## TBD
+
+* The default value for `filters` in `config/bugsnag.php` is now `null` instead of `['password']`. This allows the default filters from Bugsnag PHP to be used. Existing projects can make the same change to benefit from the new default filters in [Bugsnag PHP v3.23.0](https://github.com/bugsnag/bugsnag-php/releases/tag/v3.23.0)
+  [#413](https://github.com/bugsnag/bugsnag-laravel/pull/413)
+
 ## 2.20.0 (2020-09-09)
 
 ### Enhancements
@@ -69,7 +74,7 @@ Changelog
 
 ### Bug Fixes
 
-* Changed caching TTL to use DateTime instead. 
+* Changed caching TTL to use DateTime instead.
   [Mozammil Khodabacchas](https://github.com/mozammil)
   [#344](https://github.com/bugsnag/bugsnag-laravel/pull/344)
 * Update axiom dependency in laravel56 example to remove security vulnerability warning

--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -77,7 +77,7 @@ return [
     |
     */
 
-    'filters' => empty(env('BUGSNAG_FILTERS')) ? ['password'] : explode(',', str_replace(' ', '', env('BUGSNAG_FILTERS'))),
+    'filters' => empty(env('BUGSNAG_FILTERS')) ? null : explode(',', str_replace(' ', '', env('BUGSNAG_FILTERS'))),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Goal

Currently Bugsnag Laravel has its own list of default filters that duplicate the ones in Bugsnag PHP. This means [the recent updates to the default filters](https://github.com/bugsnag/bugsnag-php/releases/tag/v3.23.0) won't get pulled into Laravel projects

This PR removes the duplicated set of defaults so that it used the Bugsnag PHP defaults instead

This unfortunately won't apply to existing projects that have their own `config/bugsnag.php` file — they will have to make the same change to pickup the Bugsnag PHP defaults

## Changeset

- The default config value for `filters` is now `null`, which will mean no filters get set so the default filters are still used (this is existing logic in [`BugsnagServiceProvider`](https://github.com/bugsnag/bugsnag-laravel/blob/master/src/BugsnagServiceProvider.php#L212-L214))

## Testing

Unit tests have been added for the various ways of setting `filters`