### PR TITLE
Release v2.20.1

### DIFF
--- a/.ci/patches/Dockerfile.patch
+++ b/.ci/patches/Dockerfile.patch
@@ -1,0 +1,22 @@
+diff --git a/Dockerfile b/Dockerfile
+new file mode 100644
+index 0000000..ecc7d44
+--- /dev/null
++++ b/Dockerfile
+@@ -0,0 +1,16 @@
++FROM php:latest
++
++RUN apt-get update && \
++  apt-get install -y --no-install-recommends \
++  git \
++  unzip \
++  wget \
++  zip
++
++WORKDIR /app
++
++COPY . .
++
++RUN php artisan key:generate
++
++CMD php -S 0.0.0.0:8000 server.php

--- a/.ci/patches/logging.patch
+++ b/.ci/patches/logging.patch
@@ -1,0 +1,20 @@
+diff --git a/config/logging.php b/config/logging.php
+index 088c204..107a3c7 100644
+--- a/config/logging.php
++++ b/config/logging.php
+@@ -37,10 +37,14 @@ return [
+     'channels' => [
+         'stack' => [
+             'driver' => 'stack',
+-            'channels' => ['single'],
++            'channels' => ['single', 'bugsnag'],
+             'ignore_exceptions' => false,
+         ],
+ 
++        'bugsnag' => [
++            'driver' => 'bugsnag'
++        ],
++
+         'single' => [
+             'driver' => 'single',
+             'path' => storage_path('logs/laravel.log'),

--- a/.ci/patches/middleware.patch
+++ b/.ci/patches/middleware.patch
@@ -1,0 +1,98 @@
+diff --git a/app/Http/Kernel.php b/app/Http/Kernel.php
+index 36ced13..71cc168 100644
+--- a/app/Http/Kernel.php
++++ b/app/Http/Kernel.php
+@@ -62,5 +62,9 @@ class Kernel extends HttpKernel
+         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
+         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
++        'unMidEx' => \App\Http\Middleware\UnhandledMiddlewareEx::class,
++        'unMidErr' => \App\Http\Middleware\UnhandledMiddlewareErr::class,
++        'hanMidEx' => \App\Http\Middleware\HandledMiddlewareEx::class,
++        'hanMidErr' => \App\Http\Middleware\HandledMiddlewareErr::class,
+     ];
+ }
+diff --git a/app/Http/Middleware/HandledMiddlewareErr.php b/app/Http/Middleware/HandledMiddlewareErr.php
+new file mode 100644
+index 0000000..f10e6d5
+--- /dev/null
++++ b/app/Http/Middleware/HandledMiddlewareErr.php
+@@ -0,0 +1,15 @@
++<?php
++
++namespace App\Http\Middleware;
++
++use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
++use Closure;
++
++class HandledMiddlewareErr
++{
++    public function handle($request, Closure $next)
++    {
++        Bugsnag::notifyError('Handled middleware error', 'This is a handled error');
++        return $next($request);
++    }
++}
+diff --git a/app/Http/Middleware/HandledMiddlewareEx.php b/app/Http/Middleware/HandledMiddlewareEx.php
+new file mode 100644
+index 0000000..9456ce8
+--- /dev/null
++++ b/app/Http/Middleware/HandledMiddlewareEx.php
+@@ -0,0 +1,16 @@
++<?php
++
++namespace App\Http\Middleware;
++
++use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
++use Closure;
++use Exception;
++
++class HandledMiddlewareEx
++{
++    public function handle($request, Closure $next)
++    {
++        Bugsnag::notifyException(new Exception('Handled middleware exception'));
++        return $next($request);
++    }
++}
+diff --git a/app/Http/Middleware/UnhandledMiddlewareErr.php b/app/Http/Middleware/UnhandledMiddlewareErr.php
+new file mode 100644
+index 0000000..f28d7e8
+--- /dev/null
++++ b/app/Http/Middleware/UnhandledMiddlewareErr.php
+@@ -0,0 +1,14 @@
++<?php
++
++namespace App\Http\Middleware;
++
++use Closure;
++
++class UnhandledMiddlewareErr
++{
++    public function handle($request, Closure $next)
++    {
++        foo();
++        return $next($request);
++    }
++}
+diff --git a/app/Http/Middleware/UnhandledMiddlewareEx.php b/app/Http/Middleware/UnhandledMiddlewareEx.php
+new file mode 100644
+index 0000000..3559022
+--- /dev/null
++++ b/app/Http/Middleware/UnhandledMiddlewareEx.php
+@@ -0,0 +1,15 @@
++<?php
++
++namespace App\Http\Middleware;
++
++use Closure;
++use Exception;
++
++class UnhandledMiddlewareEx
++{
++    public function handle($request, Closure $next)
++    {
++        throw new Exception('Unhandled middleware exception');
++        return $next($request);
++    }
++}

--- a/.ci/patches/register-service-provider-and-facade.patch
+++ b/.ci/patches/register-service-provider-and-facade.patch
@@ -1,0 +1,21 @@
+diff --git a/config/app.php b/config/app.php
+index 8409e00..3592882 100644
+--- a/config/app.php
++++ b/config/app.php
+@@ -165,6 +165,7 @@ return [
+         /*
+          * Package Service Providers...
+          */
++        Bugsnag\BugsnagLaravel\BugsnagServiceProvider::class,
+ 
+         /*
+          * Application Service Providers...
+@@ -227,6 +228,8 @@ return [
+         'Validator' => Illuminate\Support\Facades\Validator::class,
+         'View' => Illuminate\Support\Facades\View::class,
+ 
++        'Bugsnag' => Bugsnag\BugsnagLaravel\Facades\Bugsnag::class,
++
+     ],
+ 
+ ];

--- a/.ci/patches/test-controller.patch
+++ b/.ci/patches/test-controller.patch
@@ -1,0 +1,39 @@
+diff --git a/app/Http/Controllers/TestController.php b/app/Http/Controllers/TestController.php
+new file mode 100644
+index 0000000..35978b7
+--- /dev/null
++++ b/app/Http/Controllers/TestController.php
+@@ -0,0 +1,33 @@
++<?php
++
++namespace App\Http\Controllers;
++
++use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
++use Exception;
++
++class TestController extends Controller
++{
++    public function unhandledException()
++    {
++        throw new Exception('Crashing exception!');
++    }
++
++    public function unhandledError()
++    {
++        foo();
++    }
++
++    public function handledException()
++    {
++        Bugsnag::notifyException(new Exception('Handled exception'));
++
++        return 'done';
++    }
++
++    public function handledError()
++    {
++        Bugsnag::notifyError('Handled error', 'This is a handled error');
++
++        return 'done';
++    }
++}

--- a/.ci/patches/views.patch
+++ b/.ci/patches/views.patch
@@ -1,0 +1,72 @@
+diff --git a/resources/views/handlederror.blade.php b/resources/views/handlederror.blade.php
+new file mode 100644
+index 0000000..093b53f
+--- /dev/null
++++ b/resources/views/handlederror.blade.php
+@@ -0,0 +1,12 @@
++<!doctype html>
++<html lang="{{ app()->getLocale() }}">
++    <head>
++        <meta charset="utf-8">
++        <meta http-equiv="X-UA-Compatible" content="IE=edge">
++        <meta name="viewport" content="width=device-width, initial-scale=1">
++        <title>Laravel</title>
++    </head>
++    <body>
++        <?php app('bugsnag')->notifyError("Handled error", "This is a handled error") ?>
++    </body>
++</html>
+diff --git a/resources/views/handledexception.blade.php b/resources/views/handledexception.blade.php
+new file mode 100644
+index 0000000..7de6e66
+--- /dev/null
++++ b/resources/views/handledexception.blade.php
+@@ -0,0 +1,12 @@
++<!doctype html>
++<html lang="{{ app()->getLocale() }}">
++    <head>
++        <meta charset="utf-8">
++        <meta http-equiv="X-UA-Compatible" content="IE=edge">
++        <meta name="viewport" content="width=device-width, initial-scale=1">
++        <title>Laravel</title>
++    </head>
++    <body>
++        <?php app('bugsnag')->notifyException(new Exception("Handled view exception")) ?>
++    </body>
++</html>
+diff --git a/resources/views/unhandlederror.blade.php b/resources/views/unhandlederror.blade.php
+new file mode 100644
+index 0000000..91bf125
+--- /dev/null
++++ b/resources/views/unhandlederror.blade.php
+@@ -0,0 +1,12 @@
++<!doctype html>
++<html lang="{{ app()->getLocale() }}">
++    <head>
++        <meta charset="utf-8">
++        <meta http-equiv="X-UA-Compatible" content="IE=edge">
++        <meta name="viewport" content="width=device-width, initial-scale=1">
++        <title>Laravel</title>
++    </head>
++    <body>
++        <?php foo() ?>
++    </body>
++</html>
+diff --git a/resources/views/unhandledexception.blade.php b/resources/views/unhandledexception.blade.php
+new file mode 100644
+index 0000000..c0ee78f
+--- /dev/null
++++ b/resources/views/unhandledexception.blade.php
+@@ -0,0 +1,12 @@
++<!doctype html>
++<html lang="{{ app()->getLocale() }}">
++    <head>
++        <meta charset="utf-8">
++        <meta http-equiv="X-UA-Compatible" content="IE=edge">
++        <meta name="viewport" content="width=device-width, initial-scale=1">
++        <title>Laravel</title>
++    </head>
++    <body>
++        <?php throw new Exception("Unhandled exception") ?>
++    </body>
++</html>

--- a/.ci/patches/web-routes.patch
+++ b/.ci/patches/web-routes.patch
@@ -1,0 +1,50 @@
+diff --git a/routes/web.php b/routes/web.php
+index b130397..4b89d73 100644
+--- a/routes/web.php
++++ b/routes/web.php
+@@ -1,5 +1,6 @@
+ <?php
+
++use App\Http\Controllers\TestController;
+ use Illuminate\Support\Facades\Route;
+
+ /*
+@@ -16,3 +17,38 @@ use Illuminate\Support\Facades\Route;
+ Route::get('/', function () {
+     return view('welcome');
+ });
++
++Route::get('/unhandled_exception', function () {
++    throw new Exception('Crashing exception!');
++});
++
++Route::get('/unhandled_error', function () {
++    call_foo();
++});
++
++Route::get('/handled_exception', function () {
++    Bugsnag::notifyException(new Exception('Handled exception!'));
++});
++
++Route::get('/handled_error', function () {
++    Bugsnag::notifyError('Handled Error', 'This is a handled error');
++});
++
++Route::get('/unhandled_controller_exception', [TestController::class, 'unhandledException']);
++Route::get('/unhandled_controller_error', [TestController::class, 'unhandledError']);
++Route::get('/handled_controller_exception', [TestController::class, 'handledException']);
++Route::get('/handled_controller_error', [TestController::class, 'handledError']);
++
++Route::get('/unhandled_middleware_exception', function () {
++})->middleware('unMidEx');
++Route::get('/unhandled_middleware_error', function () {
++})->middleware('unMidErr');
++Route::get('/handled_middleware_exception', function () {
++})->middleware('hanMidEx');
++Route::get('/handled_middleware_error', function () {
++})->middleware('hanMidErr');
++
++Route::view('/unhandled_view_exception', 'unhandledexception');
++Route::view('/unhandled_view_error', 'unhandlederror');
++Route::view('/handled_view_exception', 'handledexception');
++Route::view('/handled_view_error', 'handlederror');

--- a/.ci/setup-laravel-dev-fixture.sh
+++ b/.ci/setup-laravel-dev-fixture.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+
+set -e
+
+cd features/fixtures
+
+rm -rf laravel-latest
+
+# Ignore dev dependencies because we don't need them to run the Maze Runner tests
+# and they will only introduce more failure points
+composer create-project laravel/laravel laravel-latest --no-dev
+
+cd laravel-latest
+
+composer require 'laravel/framework:dev-master as 8' --update-with-dependencies --no-update
+composer require bugsnag/bugsnag-laravel --no-update
+
+composer update --no-dev
+
+printf "\nCreated Laravel project using these versions:\n"
+
+composer show --direct
+
+printf "\nApplying patches...\n"
+
+for patch in ../../../.ci/patches/*.patch; do
+    patch -p1 < "$patch"
+done

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,9 +3,11 @@
 /example export-ignore
 /features export-ignore
 /tests export-ignore
+/.ci export-ignore
 /.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
+/.github export-ignore
 /.styleci.yml export-ignore
 /.travis.yml export-ignore
 /CONTRIBUTING.md export-ignore
@@ -13,4 +15,3 @@
 /README.md export-ignore
 /Makefile export-ignore
 /phpunit.xml.dist export-ignore
-/.github export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 Gemfile.lock
 maze_output
 .phpunit.result.cache
+/features/fixtures/laravel-latest/*
+!/features/fixtures/laravel-latest/.gitignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,124 +1,170 @@
 language: php
 
+stages:
+  # Run tests against unstable Laravel versions for builds triggered by a cron
+  - name: Unstable
+    if: type = cron
+  - Canary
+  - Test
+  - Maze Runner
+
 matrix:
   include:
     - php: 5.5.9
       dist: trusty
       env: LARAVEL_VERSION=5.1.*
+      stage: Canary
     - php: 5.5
       dist: trusty
       env: LARAVEL_VERSION=5.1.*
+      stage: Canary
     - php: 5.5
       dist: trusty
       env: LARAVEL_VERSION=5.2.*
+      stage: Canary
     - php: 5.6
       dist: xenial
       env: LARAVEL_VERSION=5.1.*
+      stage: Test
     - php: 5.6
       dist: xenial
       env: LARAVEL_VERSION=5.2.*
+      stage: Test
     - php: 5.6
       dist: xenial
       env: LARAVEL_VERSION=5.3.*
+      stage: Canary
     - php: 5.6
       dist: xenial
       env: LARAVEL_VERSION=5.4.*
+      stage: Canary
     - php: 7.0
       dist: xenial
       env: LARAVEL_VERSION=5.1.*
+      stage: Test
     - php: 7.0
       dist: xenial
       env: LARAVEL_VERSION=5.2.*
+      stage: Test
     - php: 7.0
       dist: xenial
       env: LARAVEL_VERSION=5.3.*
     - php: 7.0
       dist: xenial
       env: LARAVEL_VERSION=5.4.*
+      stage: Test
     - php: 7.0
       dist: xenial
       env: LARAVEL_VERSION=5.5.*
+      stage: Canary
     - php: 7.1
       dist: bionic
       env: LARAVEL_VERSION=5.3.*
+      stage: Test
     - php: 7.1
       dist: bionic
       env: LARAVEL_VERSION=5.4.*
+      stage: Test
     - php: 7.1
       dist: bionic
       env: LARAVEL_VERSION=5.5.*
+      stage: Test
     - php: 7.1
       dist: bionic
       env: LARAVEL_VERSION=5.6.*
+      stage: Canary
     - php: 7.1
       dist: bionic
       env: LARAVEL_VERSION=5.7.*
+      stage: Canary
     - php: 7.1
       dist: bionic
       env: LARAVEL_VERSION=5.8.*
+      stage: Canary
     - php: 7.2
       dist: bionic
       env: LARAVEL_VERSION=5.5.*
+      stage: Test
     - php: 7.2
       dist: bionic
       env: LARAVEL_VERSION=5.6.*
+      stage: Test
     - php: 7.2
       dist: bionic
       env: LARAVEL_VERSION=5.7.*
+      stage: Test
     - php: 7.2
       dist: bionic
       env: LARAVEL_VERSION=5.8.*
+      stage: Test
     - php: 7.2
       dist: bionic
       env: LARAVEL_VERSION=6.0
+      stage: Canary
     - php: 7.2
       dist: bionic
       env: LARAVEL_VERSION=7.0
+      stage: Canary
     - php: 7.2
       dist: bionic
       env: LARAVEL_VERSION=6.*
+      stage: Test
     - php: 7.2
       dist: bionic
       env: LARAVEL_VERSION=7.*
+      stage: Test
     - php: 7.3
       dist: bionic
       env: LARAVEL_VERSION=5.5.*
+      stage: Test
     - php: 7.3
       dist: bionic
       env: LARAVEL_VERSION=5.6.*
+      stage: Test
     - php: 7.3
       dist: bionic
       env: LARAVEL_VERSION=5.7.*
+      stage: Test
     - php: 7.3
       dist: bionic
       env: LARAVEL_VERSION=5.8.*
+      stage: Test
     - php: 7.3
       dist: bionic
       env: LARAVEL_VERSION=6.*
+      stage: Test
     - php: 7.3
       dist: bionic
       env: LARAVEL_VERSION=7.*
+      stage: Test
     - php: 7.3
       dist: bionic
       env: LARAVEL_VERSION=8.*
+      stage: Test
     - php: 7.4
       dist: bionic
       env: LARAVEL_VERSION=5.8.*
+      stage: Test
     - php: 7.4
       dist: bionic
       env: LARAVEL_VERSION=6.0
+      stage: Test
     - php: 7.4
       dist: bionic
       env: LARAVEL_VERSION=7.0
+      stage: Test
     - php: 7.4
       dist: bionic
       env: LARAVEL_VERSION=6.*
+      stage: Canary
     - php: 7.4
       dist: bionic
       env: LARAVEL_VERSION=7.*
+      stage: Canary
     - php: 7.4
       dist: bionic
       env: LARAVEL_VERSION=8.*
+      stage: Canary
     - addons:
         apt:
           packages:
@@ -131,6 +177,7 @@ matrix:
       install: bundle install
       script: bundle exec bugsnag-maze-runner -c
       env: LARAVEL_FIXTURE=laravel56
+      stage: Maze Runner
     - addons:
         apt:
           packages:
@@ -143,6 +190,7 @@ matrix:
       install: bundle install
       script: bundle exec bugsnag-maze-runner -c
       env: LARAVEL_FIXTURE=laravel58
+      stage: Maze Runner
     - addons:
         apt:
           packages:
@@ -155,19 +203,46 @@ matrix:
       install: bundle install
       script: bundle exec bugsnag-maze-runner -c
       env: LARAVEL_FIXTURE=laravel66
+      stage: Maze Runner
+
+    - php: 7.4
+      dist: bionic
+      env: LARAVEL_VERSION='8.x-dev as 8'
+      stage: Unstable
+    - php: 7.4
+      dist: bionic
+      env: LARAVEL_VERSION='dev-master as 8'
+      stage: Unstable
+    - addons:
+        apt:
+          packages:
+          - docker-ce
+      sudo: required
+      sevices:
+      - docker
+      rvm: 2.4.1
+      php: 7.4
+      before_install: ruby --version
+      install:
+        - bundle install
+        - ./.ci/setup-laravel-dev-fixture.sh
+      script: bundle exec bugsnag-maze-runner -c
+      env: LARAVEL_FIXTURE=laravel-latest
+      stage: Unstable
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_install:
-  - travis_retry composer require "laravel/framework:${LARAVEL_VERSION}" --no-update
   - echo "memory_limit=4G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install:
+  - composer require "laravel/framework:${LARAVEL_VERSION}" --no-update
   - if [[ $TRAVIS_PHP_VERSION == 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-dist --prefer-lowest ; fi
   - if [[ $TRAVIS_PHP_VERSION != 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-dist ; fi
-  - composer show laravel/framework
+  # Show which versions of our direct dependencies we're using
+  - composer show --direct
 
 script:
   - make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## TBD
+
+* The default value for `filters` in `config/bugsnag.php` is now `null` instead of `['password']`. This allows the default filters from Bugsnag PHP to be used. Existing projects can make the same change to benefit from the new default filters in [Bugsnag PHP v3.23.0](https://github.com/bugsnag/bugsnag-php/releases/tag/v3.23.0)
+  [#413](https://github.com/bugsnag/bugsnag-laravel/pull/413)
+
 ## 2.20.0 (2020-09-09)
 
 ### Enhancements
@@ -69,7 +74,7 @@ Changelog
 
 ### Bug Fixes
 
-* Changed caching TTL to use DateTime instead. 
+* Changed caching TTL to use DateTime instead.
   [Mozammil Khodabacchas](https://github.com/mozammil)
   [#344](https://github.com/bugsnag/bugsnag-laravel/pull/344)
 * Update axiom dependency in laravel56 example to remove security vulnerability warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## TBD
+## 2.20.1 (2020-10-13)
 
 * The default value for `filters` in `config/bugsnag.php` is now `null` instead of `['password']`. This allows the default filters from Bugsnag PHP to be used. Existing projects can make the same change to benefit from the new default filters in [Bugsnag PHP v3.23.0](https://github.com/bugsnag/bugsnag-php/releases/tag/v3.23.0)
   [#413](https://github.com/bugsnag/bugsnag-laravel/pull/413)

--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -77,7 +77,7 @@ return [
     |
     */
 
-    'filters' => empty(env('BUGSNAG_FILTERS')) ? ['password'] : explode(',', str_replace(' ', '', env('BUGSNAG_FILTERS'))),
+    'filters' => empty(env('BUGSNAG_FILTERS')) ? null : explode(',', str_replace(' ', '', env('BUGSNAG_FILTERS'))),
 
     /*
     |--------------------------------------------------------------------------

--- a/features/fixtures/docker-compose.yaml
+++ b/features/fixtures/docker-compose.yaml
@@ -39,3 +39,17 @@ services:
       - target: 8000
         published: 61266
     restart: "no"
+
+  laravel-latest:
+    build:
+      context: laravel-latest
+    environment:
+      - BUGSNAG_API_KEY
+      - BUGSNAG_ENDPOINT
+      - BUGSNAG_SESSION_ENDPOINT
+      - BUGSNAG_CAPTURE_SESSIONS
+    restart: "no"
+    ports:
+      - target: 8000
+        published: 61299
+    restart: "no"

--- a/features/fixtures/laravel-latest/.gitignore
+++ b/features/fixtures/laravel-latest/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/features/runtime_versions.feature
+++ b/features/runtime_versions.feature
@@ -15,7 +15,7 @@ Scenario: report for handled event contains runtime version information
   And the request is a valid for the error reporting API
   And the event "unhandled" is false
   And the event "device.runtimeVersions.php" matches "(\d+\.){2}\d+"
-  And the event "device.runtimeVersions.laravel" matches "(\d+\.){2}\d+"
+  And the event "device.runtimeVersions.laravel" matches "((\d+\.){2}\d+|\d\.x-dev)"
 
 Scenario: report for unhandled event contains runtime version information
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
@@ -28,7 +28,7 @@ Scenario: report for unhandled event contains runtime version information
   And the request is a valid for the error reporting API
   And the event "unhandled" is true
   And the event "device.runtimeVersions.php" matches "(\d+\.){2}\d+"
-  And the event "device.runtimeVersions.laravel" matches "(\d+\.){2}\d+"
+  And the event "device.runtimeVersions.laravel" matches "((\d+\.){2}\d+|\d\.x-dev)"
 
 Scenario: session payload contains runtime version information
   Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
@@ -42,4 +42,4 @@ Scenario: session payload contains runtime version information
   And the request 0 is valid for the session tracking API
   And the payload has a valid sessions array for request 0
   And the payload field "device.runtimeVersions.php" matches the regex "(\d+\.){2}\d+"
-  And the payload field "device.runtimeVersions.laravel" matches the regex "(\d+\.){2}\d+"
+  And the payload field "device.runtimeVersions.laravel" matches the regex "((\d+\.){2}\d+|\d\.x-dev)"

--- a/features/steps/laravel_steps.rb
+++ b/features/steps/laravel_steps.rb
@@ -14,13 +14,13 @@ end
 
 When(/^I wait for the app to respond on the appropriate port$/) do
   steps %{
-    When I wait for the app to respond on port "#{getLaravelPort}"
+    When I wait for the app to respond on port "#{fixture_port}"
   }
 end
 
 When("I navigate to the route {string}") do |route|
   steps %{
-    When I navigate to the route "#{route}" on port "#{getLaravelPort}"
+    When I navigate to the route "#{route}" on port "#{fixture_port}"
   }
 end
 
@@ -29,13 +29,12 @@ Then("the exception {string} matches one of the following:") do |path, values|
   assert_includes(values.raw.flatten, desired_value)
 end
 
-def getLaravelPort
+def fixture_port
   case ENV['LARAVEL_FIXTURE']
-  when 'laravel66'
-    61266
-  when 'laravel58'
-    61258
-  else
-    61256
+  when 'laravel-latest' then 61299
+  when 'laravel66' then 61266
+  when 'laravel58' then 61258
+  when 'laravel56' then 61256
+  else raise "Unknown laravel fixture '#{ENV['LARAVEL_FIXTURE']}'!"
   end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,6 +7,8 @@ VENDORED_LIB = FIXTURE_DIR + '/bugsnag-laravel.zip'
 
 `composer archive -f zip --dir=#{File.dirname(VENDORED_LIB)} --file=#{File.basename(VENDORED_LIB, '.zip')}`
 Dir.glob(FIXTURE_DIR + '/laravel*').each do |directory|
+  next if directory.end_with?('laravel-latest')
+
   FileUtils.cp(VENDORED_LIB, directory + '/bugsnag-laravel.zip')
   # Remove any locally installed composer deps
   FileUtils.rm_rf(directory + '/vendor')
@@ -18,6 +20,8 @@ File.open('composer.json', 'r') do |source|
   parsed_composer = JSON.parse source.read
   requirements = parsed_composer["require"]
   Dir.glob(FIXTURE_DIR + '/laravel*').each do |directory|
+    next if directory.end_with?('laravel-latest')
+
     File.open(directory + '/composer.json.template', 'r') do |template|
       parsed_template = JSON.parse template.read
       parsed_template["repositories"][0]["package"]["require"] = requirements

--- a/features/unhandled_controller.feature
+++ b/features/unhandled_controller.feature
@@ -32,7 +32,7 @@ Scenario: Unhandled errors are delivered from controllers
   And the request is a valid for the error reporting API
   And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the payload field "events" is an array with 1 element
-  And the exception "errorClass" ends with "FatalThrowableError"
+  And the exception "errorClass" ends with "Error"
   And the exception "message" starts with "Call to undefined function"
   And the exception "message" ends with "foo()"
   And the event "metaData.request.httpMethod" equals "GET"

--- a/features/unhandled_middleware.feature
+++ b/features/unhandled_middleware.feature
@@ -32,7 +32,7 @@ Scenario: Unhandled errors are delivered from middleware
   And the request is a valid for the error reporting API
   And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the payload field "events" is an array with 1 element
-  And the exception "errorClass" ends with "FatalThrowableError"
+  And the exception "errorClass" ends with "Error"
   And the exception "message" starts with "Call to undefined function"
   And the exception "message" ends with "foo()"
   And the event "metaData.request.httpMethod" equals "GET"

--- a/features/unhandled_routing.feature
+++ b/features/unhandled_routing.feature
@@ -32,7 +32,7 @@ Scenario: Unhandled errors are delivered from routing
   And the request is a valid for the error reporting API
   And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the payload field "events" is an array with 1 element
-  And the exception "errorClass" ends with "FatalThrowableError"
+  And the exception "errorClass" ends with "Error"
   And the exception "message" equals "Call to undefined function call_foo()"
   And the event "metaData.request.httpMethod" equals "GET"
   And the event "app.type" equals "HTTP"

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -36,7 +36,7 @@ class BugsnagServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    const VERSION = '2.20.0';
+    const VERSION = '2.20.1';
 
     /**
      * Boot the service provider.


### PR DESCRIPTION
* The default value for `filters` in `config/bugsnag.php` is now `null` instead of `['password']`. This allows the default filters from Bugsnag PHP to be used. Existing projects can make the same change to benefit from the new default filters in [Bugsnag PHP v3.23.0](https://github.com/bugsnag/bugsnag-php/releases/tag/v3.23.0)
  [#413](https://github.com/bugsnag/bugsnag-laravel/pull/413)

---

Also contains CI changes to test against upcoming Laravel versions (hence the big diff!)