### PR TITLE
Run unit tests against PHP 8 on CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -92,6 +92,15 @@ jobs:
             laravel-version: '7.*'
           - php-version: 7.4
             laravel-version: '8.*'
+          - php-version: 8.0
+            laravel-version: '6.*'
+            composer-flags: '--ignore-platform-reqs'
+          - php-version: 8.0
+            laravel-version: '7.*'
+            composer-flags: '--ignore-platform-reqs'
+          - php-version: 8.0
+            laravel-version: '8.*'
+            composer-flags: '--ignore-platform-reqs'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Goal

This PR adds PHP 8 to the unit test matrix. Laravel doesn't fully support PHP 8 yet but our unit tests pass anyway, so there's no harm to this change

I haven't added PHP 8 to the Maze Runner tests as I think it makes sense to wait for the official PHP 8 tag there, rather than running against a RC