### PR TITLE
Fix maze runner tests / migrate to maze runner v3

### DIFF
--- a/.github/workflows/maze-runner-tests.yml
+++ b/.github/workflows/maze-runner-tests.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install libcurl4-openssl-dev
+      run: sudo apt-get install libcurl4-openssl-dev
+
     - name: install Ruby
       uses: actions/setup-ruby@v1
       with:
@@ -27,4 +30,4 @@ jobs:
 
     - run: bundle install
 
-    - run: PHP_VERSION=${{ matrix.php-version }} LARAVEL_FIXTURE=${{ matrix.laravel-fixture }} bundle exec bugsnag-maze-runner -c
+    - run: PHP_VERSION=${{ matrix.php-version }} LARAVEL_FIXTURE=${{ matrix.laravel-fixture }} bundle exec bugsnag-maze-runner

--- a/.github/workflows/unstable-version-tests.yml
+++ b/.github/workflows/unstable-version-tests.yml
@@ -42,6 +42,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install libcurl4-openssl-dev
+      run: sudo apt-get install libcurl4-openssl-dev
+
     - name: install Ruby
       uses: actions/setup-ruby@v1
       with:
@@ -53,4 +56,4 @@ jobs:
 
     - run: ./.ci/setup-laravel-dev-fixture.sh
 
-    - run: PHP_VERSION=${{ matrix.php-version }} LARAVEL_FIXTURE=${{ matrix.laravel-fixture }} bundle exec bugsnag-maze-runner -c
+    - run: PHP_VERSION=${{ matrix.php-version }} LARAVEL_FIXTURE=${{ matrix.laravel-fixture }} bundle exec bugsnag-maze-runner

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', :git => 'https://github.com/bugsnag/maze-runner', :branch => 'v1'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.5.1'
 gem "os", "~> 1.0"

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -14,7 +14,6 @@ services:
     ports:
       - target: 8000
         published: 61256
-    restart: "no"
 
   laravel58:
     build:
@@ -30,7 +29,6 @@ services:
     ports:
       - target: 8000
         published: 61258
-    restart: "no"
 
   laravel66:
     build:
@@ -46,7 +44,6 @@ services:
     ports:
       - target: 8000
         published: 61266
-    restart: "no"
 
   laravel-latest:
     build:
@@ -62,4 +59,3 @@ services:
     ports:
       - target: 8000
         published: 61299
-    restart: "no"

--- a/features/fixtures/laravel56/composer.json.template
+++ b/features/fixtures/laravel56/composer.json.template
@@ -8,7 +8,7 @@
         {
             "type": "package",
             "package": {
-                "name": "bugsnag-laravel",
+                "name": "bugsnag/bugsnag-laravel",
                 "version": "4.0",
                 "dist": {
                     "url": "./bugsnag-laravel.zip",
@@ -25,7 +25,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "bugsnag-laravel": "4.0",
+        "bugsnag/bugsnag-laravel": "4.0",
         "fideloper/proxy": "~4.0",
         "laravel/framework": "5.6.*",
         "laravel/tinker": "~1.0"

--- a/features/fixtures/laravel58/composer.json.template
+++ b/features/fixtures/laravel58/composer.json.template
@@ -11,7 +11,7 @@
         {
             "type": "package",
             "package": {
-                "name": "bugsnag-laravel",
+                "name": "bugsnag/bugsnag-laravel",
                 "version": "4.0",
                 "dist": {
                     "url": "./bugsnag-laravel.zip",
@@ -28,7 +28,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "bugsnag-laravel": "4.0",
+        "bugsnag/bugsnag-laravel": "4.0",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "5.8.*",
         "laravel/tinker": "^1.0"

--- a/features/fixtures/laravel66/composer.json.template
+++ b/features/fixtures/laravel66/composer.json.template
@@ -11,7 +11,7 @@
         {
             "type": "package",
             "package": {
-                "name": "bugsnag-laravel",
+                "name": "bugsnag/bugsnag-laravel",
                 "version": "4.0",
                 "dist": {
                     "url": "./bugsnag-laravel.zip",
@@ -28,7 +28,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "bugsnag/bugsnag-laravel": "^2.0",
+        "bugsnag/bugsnag-laravel": "4.0",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "^6.2",
         "laravel/tinker": "^2.0"

--- a/features/handled_controller.feature
+++ b/features/handled_controller.feature
@@ -1,16 +1,10 @@
 Feature: Handled exceptions in controllers support
 
 Scenario: Handled exceptions are delivered from controllers
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/handled_controller_exception"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the payload field "events" is an array with 1 element
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "Exception"
   And the exception "message" starts with "Handled exception"
   And the event "metaData.request.httpMethod" equals "GET"
@@ -21,16 +15,10 @@ Scenario: Handled exceptions are delivered from controllers
   And the event "severityReason.type" equals "handledException"
 
 Scenario: Handled errors are delivered from controllers
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/handled_controller_error"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the payload field "events" is an array with 1 element
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" ends with "Handled error"
   And the exception "message" equals "This is a handled error"
   And the event "metaData.request.httpMethod" equals "GET"
@@ -41,16 +29,12 @@ Scenario: Handled errors are delivered from controllers
   And the event "severityReason.type" equals "handledError"
 
 Scenario: Sessions are correct in handled exceptions from controllers
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I enable session tracking
+  Given I enable session tracking
   And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
   When I navigate to the route "/handled_controller_exception"
-  And I wait for 1 second
-  Then I should receive 2 requests
-  And the request 0 is valid for the session tracking API
-  And the request 1 is a valid for the error reporting API
-  And the payload has a valid sessions array for request 0
-  And the payload field "events.0.session.events.unhandled" equals 0 for request 1
-  And the payload field "events.0.session.events.handled" equals 1 for request 1
+  And I wait to receive 2 requests
+  Then the request is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier
+  When I discard the oldest request
+  Then the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
+  And the payload field "events.0.session.events.unhandled" equals 0
+  And the payload field "events.0.session.events.handled" equals 1

--- a/features/handled_middleware.feature
+++ b/features/handled_middleware.feature
@@ -1,16 +1,10 @@
 Feature: Handled exceptions for middleware support
 
 Scenario: Handled exceptions are delivered from middleware
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/handled_middleware_exception"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the payload field "events" is an array with 1 element
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "Exception"
   And the exception "message" starts with "Handled middleware exception"
   And the event "metaData.request.httpMethod" equals "GET"
@@ -21,16 +15,10 @@ Scenario: Handled exceptions are delivered from middleware
   And the event "severityReason.type" equals "handledException"
 
 Scenario: Handled errors are delivered from middleware
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/handled_middleware_error"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the payload field "events" is an array with 1 element
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" ends with "Handled middleware error"
   And the exception "message" equals "This is a handled error"
   And the event "metaData.request.httpMethod" equals "GET"
@@ -41,16 +29,12 @@ Scenario: Handled errors are delivered from middleware
   And the event "severityReason.type" equals "handledError"
 
 Scenario: Sessions are correct in handled exceptions from middleware
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I enable session tracking
+  Given I enable session tracking
   And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
   When I navigate to the route "/handled_middleware_exception"
-  And I wait for 1 second
-  Then I should receive 2 requests
-  And the request 0 is valid for the session tracking API
-  And the request 1 is a valid for the error reporting API
-  And the payload has a valid sessions array for request 0
-  And the payload field "events.0.session.events.unhandled" equals 0 for request 1
-  And the payload field "events.0.session.events.handled" equals 1 for request 1
+  And I wait to receive 2 requests
+  Then the request is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier
+  When I discard the oldest request
+  Then the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
+  And the payload field "events.0.session.events.unhandled" equals 0
+  And the payload field "events.0.session.events.handled" equals 1

--- a/features/handled_routing.feature
+++ b/features/handled_routing.feature
@@ -1,16 +1,10 @@
 Feature: Handled exceptions from routing support
 
 Scenario: Handled exceptions are delivered from routing
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/handled_exception"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the payload field "events" is an array with 1 element
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "Exception"
   And the exception "message" starts with "Handled exception!"
   And the event "metaData.request.httpMethod" equals "GET"
@@ -21,16 +15,10 @@ Scenario: Handled exceptions are delivered from routing
   And the event "severityReason.type" equals "handledException"
 
 Scenario: Handled errors are delivered from routing
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/handled_error"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the payload field "events" is an array with 1 element
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "Handled Error"
   And the exception "message" equals "This is a handled error"
   And the event "metaData.request.httpMethod" equals "GET"
@@ -41,16 +29,12 @@ Scenario: Handled errors are delivered from routing
   And the event "severityReason.type" equals "handledError"
 
 Scenario: Sessions are correct in handled exceptions from routing
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I enable session tracking
+  Given I enable session tracking
   And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
   When I navigate to the route "/handled_exception"
-  And I wait for 1 second
-  Then I should receive 2 requests
-  And the request 0 is valid for the session tracking API
-  And the request 1 is a valid for the error reporting API
-  And the payload has a valid sessions array for request 0
-  And the payload field "events.0.session.events.unhandled" equals 0 for request 1
-  And the payload field "events.0.session.events.handled" equals 1 for request 1
+  And I wait to receive 2 requests
+  Then the request is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier
+  When I discard the oldest request
+  Then the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
+  And the payload field "events.0.session.events.unhandled" equals 0
+  And the payload field "events.0.session.events.handled" equals 1

--- a/features/runtime_versions.feature
+++ b/features/runtime_versions.feature
@@ -24,7 +24,11 @@ Scenario: session payload contains runtime version information
   When I navigate to the route "/unhandled_controller_exception"
   And I wait to receive 2 requests
   Then the request is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier
+  And the payload field "device.runtimeVersions.php" matches the regex "(\d+\.){2}\d+"
+  And the payload field "device.runtimeVersions.laravel" matches the regex "((\d+\.){2}\d+|\d\.x-dev)"
   When I discard the oldest request
   Then the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the payload field "events.0.session.events.unhandled" equals 1
   And the payload field "events.0.session.events.handled" equals 0
+  And the event "device.runtimeVersions.php" matches "(\d+\.){2}\d+"
+  And the event "device.runtimeVersions.laravel" matches "((\d+\.){2}\d+|\d\.x-dev)"

--- a/features/runtime_versions.feature
+++ b/features/runtime_versions.feature
@@ -1,45 +1,30 @@
 Feature: Reporting runtime versions
 
-Background:
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-
 Scenario: report for handled event contains runtime version information
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/handled_exception"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the event "unhandled" is false
   And the event "device.runtimeVersions.php" matches "(\d+\.){2}\d+"
   And the event "device.runtimeVersions.laravel" matches "((\d+\.){2}\d+|\d\.x-dev)"
 
 Scenario: report for unhandled event contains runtime version information
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/unhandled_exception"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the event "unhandled" is true
   And the event "device.runtimeVersions.php" matches "(\d+\.){2}\d+"
   And the event "device.runtimeVersions.laravel" matches "((\d+\.){2}\d+|\d\.x-dev)"
 
 Scenario: session payload contains runtime version information
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I enable session tracking
+  Given I enable session tracking
   And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
   When I navigate to the route "/unhandled_controller_exception"
-  And I wait for 1 second
-  Then I should receive 2 requests
-  And the request 0 is valid for the session tracking API
-  And the payload has a valid sessions array for request 0
-  And the payload field "device.runtimeVersions.php" matches the regex "(\d+\.){2}\d+"
-  And the payload field "device.runtimeVersions.laravel" matches the regex "((\d+\.){2}\d+|\d\.x-dev)"
+  And I wait to receive 2 requests
+  Then the request is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier
+  When I discard the oldest request
+  Then the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
+  And the payload field "events.0.session.events.unhandled" equals 1
+  And the payload field "events.0.session.events.handled" equals 0

--- a/features/steps/laravel_steps.rb
+++ b/features/steps/laravel_steps.rb
@@ -1,40 +1,61 @@
+require 'net/http'
+
 Given(/^I enable session tracking$/) do
   steps %{
     When I set environment variable "BUGSNAG_CAPTURE_SESSIONS" to "true"
-    And I set environment variable "BUGSNAG_SESSION_ENDPOINT" to "http://#{current_ip}:#{MOCK_API_PORT}"
+    And I set environment variable "BUGSNAG_SESSION_ENDPOINT" to "http://#{current_ip}:9339"
+  }
+end
+
+Given('I configure the bugsnag endpoint') do
+  steps %{
+    Given I set environment variable "BUGSNAG_ENDPOINT" to "http://#{current_ip}:9339"
   }
 end
 
 When(/^I start the laravel fixture$/) do
-  laravel_fixture = ENV['LARAVEL_FIXTURE'] || 'laravel56'
   steps %{
-    When I start the service "#{laravel_fixture}"
-  }
-end
-
-When(/^I wait for the app to respond on the appropriate port$/) do
-  steps %{
-    When I wait for the app to respond on port "#{fixture_port}"
+    When I start the service "#{fixture}"
+    And I wait for the host "localhost" to open port "#{fixture_port}"
   }
 end
 
 When("I navigate to the route {string}") do |route|
-  steps %{
-    When I navigate to the route "#{route}" on port "#{fixture_port}"
-  }
+  navigate_to(route)
 end
 
 Then("the exception {string} matches one of the following:") do |path, values|
-  desired_value = read_key_path(find_request(get_request_index(nil))[:body], "events.0.exceptions.0.#{path}")
+  desired_value = read_key_path(Server.current_request[:body], "events.0.exceptions.0.#{path}")
   assert_includes(values.raw.flatten, desired_value)
 end
 
+def fixture
+  ENV['LARAVEL_FIXTURE'] || 'laravel56'
+end
+
 def fixture_port
-  case ENV['LARAVEL_FIXTURE']
+  case fixture
   when 'laravel-latest' then 61299
   when 'laravel66' then 61266
   when 'laravel58' then 61258
   when 'laravel56' then 61256
   else raise "Unknown laravel fixture '#{ENV['LARAVEL_FIXTURE']}'!"
   end
+end
+
+def current_ip
+  return 'host.docker.internal' if OS.mac?
+
+  ip_addr = `ifconfig | grep -Eo 'inet (addr:)?([0-9]*\\\.){3}[0-9]*' | grep -v '127.0.0.1'`
+  ip_list = /((?:[0-9]*\.){3}[0-9]*)/.match(ip_addr)
+  ip_list.captures.first
+end
+
+def navigate_to(route, attempts = 0)
+  Net::HTTP.get('localhost', route, fixture_port)
+rescue => e
+  raise "Failed to navigate to #{route} (#{e})" if attempts > 15
+
+  sleep 1
+  navigate_to(route, attempts + 1)
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,14 +17,16 @@ end
 
 # Copy current requirements into fixture requirements
 File.open('composer.json', 'r') do |source|
-  parsed_composer = JSON.parse source.read
+  parsed_composer = JSON.parse(source.read)
   requirements = parsed_composer["require"]
+
   Dir.glob(FIXTURE_DIR + '/laravel*').each do |directory|
     next if directory.end_with?('laravel-latest')
 
     File.open(directory + '/composer.json.template', 'r') do |template|
       parsed_template = JSON.parse template.read
       parsed_template["repositories"][0]["package"]["require"] = requirements
+
       File.open(directory + '/composer.json', 'w') do |target|
         target.write(JSON.pretty_generate(parsed_template))
       end
@@ -32,9 +34,9 @@ File.open('composer.json', 'r') do |source|
   end
 end
 
-
 Before do
-  find_default_docker_compose
+  ENV["BUGSNAG_API_KEY"] = $api_key
+  ENV["BUGSNAG_ENDPOINT"] = "http://#{current_ip}:9339"
 end
 
 at_exit do

--- a/features/unhandled_controller.feature
+++ b/features/unhandled_controller.feature
@@ -1,16 +1,10 @@
 Feature: Unhandled exceptions in controllers support
 
 Scenario: Unhandled exceptions are delivered from controllers
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/unhandled_controller_exception"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the payload field "events" is an array with 1 element
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "Exception"
   And the exception "message" starts with "Crashing exception!"
   And the event "metaData.request.httpMethod" equals "GET"
@@ -22,16 +16,10 @@ Scenario: Unhandled exceptions are delivered from controllers
   And the event "severityReason.attributes.framework" equals "Laravel"
 
 Scenario: Unhandled errors are delivered from controllers
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/unhandled_controller_error"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the payload field "events" is an array with 1 element
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" ends with "Error"
   And the exception "message" starts with "Call to undefined function"
   And the exception "message" ends with "foo()"
@@ -44,16 +32,12 @@ Scenario: Unhandled errors are delivered from controllers
   And the event "severityReason.attributes.framework" equals "Laravel"
 
 Scenario: Sessions are correct in unhandled exceptions from controllers
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I enable session tracking
+  Given I enable session tracking
   And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
   When I navigate to the route "/unhandled_controller_exception"
-  And I wait for 1 second
-  Then I should receive 2 requests
-  And the request 0 is valid for the session tracking API
-  And the request 1 is a valid for the error reporting API
-  And the payload has a valid sessions array for request 0
-  And the payload field "events.0.session.events.unhandled" equals 1 for request 1
-  And the payload field "events.0.session.events.handled" equals 0 for request 1
+  And I wait to receive 2 requests
+  Then the request is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier
+  When I discard the oldest request
+  Then the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
+  And the payload field "events.0.session.events.unhandled" equals 1
+  And the payload field "events.0.session.events.handled" equals 0

--- a/features/unhandled_middleware.feature
+++ b/features/unhandled_middleware.feature
@@ -1,16 +1,10 @@
 Feature: Unhandled exceptions for middleware support
 
 Scenario: Unhandled exceptions are delivered from middleware
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/unhandled_middleware_exception"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the payload field "events" is an array with 1 element
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "Exception"
   And the exception "message" starts with "Unhandled middleware exception"
   And the event "metaData.request.httpMethod" equals "GET"
@@ -22,16 +16,10 @@ Scenario: Unhandled exceptions are delivered from middleware
   And the event "severityReason.attributes.framework" equals "Laravel"
 
 Scenario: Unhandled errors are delivered from middleware
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/unhandled_middleware_error"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the payload field "events" is an array with 1 element
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" ends with "Error"
   And the exception "message" starts with "Call to undefined function"
   And the exception "message" ends with "foo()"
@@ -44,16 +32,12 @@ Scenario: Unhandled errors are delivered from middleware
   And the event "severityReason.attributes.framework" equals "Laravel"
 
 Scenario: Sessions are correct in unhandled exceptions from middleware
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I enable session tracking
+  Given I enable session tracking
   And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
   When I navigate to the route "/unhandled_middleware_exception"
-  And I wait for 1 second
-  Then I should receive 2 requests
-  And the request 0 is valid for the session tracking API
-  And the request 1 is a valid for the error reporting API
-  And the payload has a valid sessions array for request 0
-  And the payload field "events.0.session.events.unhandled" equals 1 for request 1
-  And the payload field "events.0.session.events.handled" equals 0 for request 1
+  And I wait to receive 2 requests
+  Then the request is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier
+  When I discard the oldest request
+  Then the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
+  And the payload field "events.0.session.events.unhandled" equals 1
+  And the payload field "events.0.session.events.handled" equals 0

--- a/features/unhandled_routing.feature
+++ b/features/unhandled_routing.feature
@@ -1,16 +1,10 @@
 Feature: Unhandled exceptions for routing support
 
 Scenario: Unhandled exceptions are delivered from routing
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/unhandled_exception"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the payload field "events" is an array with 1 element
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "Exception"
   And the exception "message" starts with "Crashing exception!"
   And the event "metaData.request.httpMethod" equals "GET"
@@ -22,16 +16,10 @@ Scenario: Unhandled exceptions are delivered from routing
   And the event "severityReason.attributes.framework" equals "Laravel"
 
 Scenario: Unhandled errors are delivered from routing
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/unhandled_error"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the payload field "events" is an array with 1 element
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" ends with "Error"
   And the exception "message" equals "Call to undefined function call_foo()"
   And the event "metaData.request.httpMethod" equals "GET"
@@ -43,16 +31,12 @@ Scenario: Unhandled errors are delivered from routing
   And the event "severityReason.attributes.framework" equals "Laravel"
 
 Scenario: Sessions are correct in unhandled exceptions from routing
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I enable session tracking
+  Given I enable session tracking
   And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
   When I navigate to the route "/unhandled_exception"
-  And I wait for 1 second
-  Then I should receive 2 requests
-  And the request 0 is valid for the session tracking API
-  And the request 1 is a valid for the error reporting API
-  And the payload has a valid sessions array for request 0
-  And the payload field "events.0.session.events.unhandled" equals 1 for request 1
-  And the payload field "events.0.session.events.handled" equals 0 for request 1
+  And I wait to receive 2 requests
+  Then the request is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier
+  When I discard the oldest request
+  Then the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
+  And the payload field "events.0.session.events.unhandled" equals 1
+  And the payload field "events.0.session.events.handled" equals 0

--- a/features/unhandled_view.feature
+++ b/features/unhandled_view.feature
@@ -1,16 +1,10 @@
 Feature: Unhandled exceptions for views support
 
 Scenario: Unhandled exceptions are delivered from views
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/unhandled_view_exception"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the payload field "events" is an array with 1 element
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" matches one of the following:
     | ErrorException                              |
     | Facade\\Ignition\\Exceptions\\ViewException |
@@ -24,16 +18,10 @@ Scenario: Unhandled exceptions are delivered from views
   And the event "severityReason.attributes.framework" equals "Laravel"
 
 Scenario: Unhandled errors are delivered from views
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
+  Given I start the laravel fixture
   When I navigate to the route "/unhandled_view_error"
-  And I wait for 1 second
-  Then I should receive a request
-  And the request is a valid for the error reporting API
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the payload field "events" is an array with 1 element
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" matches one of the following:
     | ErrorException                              |
     | Facade\\Ignition\\Exceptions\\ViewException |
@@ -47,16 +35,12 @@ Scenario: Unhandled errors are delivered from views
   And the event "severityReason.attributes.framework" equals "Laravel"
 
 Scenario: Sessions are correct in unhandled exceptions from views
-  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I configure the bugsnag endpoint
-  And I enable session tracking
+  Given I enable session tracking
   And I start the laravel fixture
-  And I wait for the app to respond on the appropriate port
   When I navigate to the route "/unhandled_view_exception"
-  And I wait for 1 second
-  Then I should receive 2 requests
-  And the request 0 is valid for the session tracking API
-  And the request 1 is a valid for the error reporting API
-  And the payload has a valid sessions array for request 0
-  And the payload field "events.0.session.events.unhandled" equals 1 for request 1
-  And the payload field "events.0.session.events.handled" equals 0 for request 1
+  And I wait to receive 2 requests
+  Then the request is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier
+  When I discard the oldest request
+  Then the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
+  And the payload field "events.0.session.events.unhandled" equals 1
+  And the payload field "events.0.session.events.handled" equals 0


### PR DESCRIPTION
The Maze Runner tests have been failing recently for two reasons:

1. Composer 2 is stricter with package names and refused to install our zip file in the fixtures because it didn't have a vendor prefix (i.e. was `bugsnag-laravel` but should have been `bugsnag/bugsnag-laravel`)
2. The ISO8601 timestamp regex only accepted zulu time, not the timezone offset we send

Fixing 1 was easy, but 2 needed MR changes and so I migrated to v3 to allow us to pull in the latest MR with the fix

To update to MR v3, we now need to install libcurl headers for one of its dependencies (`curb`)