### PR TITLE
Fetch the Guzzle instance from the DI container, if it exists

### DIFF
--- a/.ci/patches/register-custom-guzzle.patch
+++ b/.ci/patches/register-custom-guzzle.patch
@@ -1,0 +1,24 @@
+diff --git a/app/Providers/AppServiceProvider.php b/app/Providers/AppServiceProvider.php
+index ee8ca5b..49823ec 100644
+--- a/app/Providers/AppServiceProvider.php
++++ b/app/Providers/AppServiceProvider.php
+@@ -13,7 +13,18 @@ class AppServiceProvider extends ServiceProvider
+      */
+     public function register()
+     {
+-        //
++        if (!getenv('BUGSNAG_USE_CUSTOM_GUZZLE')) {
++            return;
++        }
++
++        $this->app->singleton('bugsnag.guzzle', function ($app) {
++            $handler = \GuzzleHttp\HandlerStack::create();
++            $handler->push(\GuzzleHttp\Middleware::mapRequest(function ($request) {
++                return $request->withHeader('X-Custom-Guzzle', 'yes');
++            }));
++
++            return new \GuzzleHttp\Client(['handler' => $handler]);
++        });
+     }
+ 
+     /**

--- a/.ci/setup-laravel-dev-fixture.sh
+++ b/.ci/setup-laravel-dev-fixture.sh
@@ -13,7 +13,8 @@ composer create-project laravel/laravel laravel-latest --no-dev
 cd laravel-latest
 
 composer require 'laravel/framework:dev-master as 8' --update-with-dependencies --no-update
-composer require bugsnag/bugsnag-laravel --no-update
+composer config repositories.bugsnag-laravel '{ "type": "path", "url": "../../../", "options": { "symlink": false } }'
+composer require bugsnag/bugsnag-laravel '*' --no-update
 
 composer update --no-dev
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Use Guzzle instance with the `bugsnag.guzzle` alias, if one exists. If no`bugsnag.guzzle` does not exist, a new Guzzle instance will be created as before
+  [#420](https://github.com/bugsnag/bugsnag-laravel/pull/420)
+
 ## 2.20.1 (2020-10-13)
 
 * The default value for `filters` in `config/bugsnag.php` is now `null` instead of `['password']`. This allows the default filters from Bugsnag PHP to be used. Existing projects can make the same change to benefit from the new default filters in [Bugsnag PHP v3.23.0](https://github.com/bugsnag/bugsnag-php/releases/tag/v3.23.0)

--- a/features/custom_guzzle.feature
+++ b/features/custom_guzzle.feature
@@ -1,0 +1,13 @@
+Feature: A custom Guzzle client can be used
+
+Scenario: A custom Guzzle client can be used
+  Given I enable session tracking
+  And I set environment variable "BUGSNAG_USE_CUSTOM_GUZZLE" to "true"
+  And I start the laravel fixture
+  When I navigate to the route "/unhandled_exception"
+  And I wait to receive 2 requests
+  Then the request is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier
+  And the "X-Custom-Guzzle" header equals "yes"
+  When I discard the oldest request
+  Then the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
+  And the "X-Custom-Guzzle" header equals "yes"

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - BUGSNAG_ENDPOINT
       - BUGSNAG_SESSION_ENDPOINT
       - BUGSNAG_CAPTURE_SESSIONS
+      - BUGSNAG_USE_CUSTOM_GUZZLE
     restart: "no"
     ports:
       - target: 8000
@@ -25,6 +26,7 @@ services:
       - BUGSNAG_ENDPOINT
       - BUGSNAG_SESSION_ENDPOINT
       - BUGSNAG_CAPTURE_SESSIONS
+      - BUGSNAG_USE_CUSTOM_GUZZLE
     restart: "no"
     ports:
       - target: 8000
@@ -40,6 +42,7 @@ services:
       - BUGSNAG_ENDPOINT
       - BUGSNAG_SESSION_ENDPOINT
       - BUGSNAG_CAPTURE_SESSIONS
+      - BUGSNAG_USE_CUSTOM_GUZZLE
     restart: "no"
     ports:
       - target: 8000
@@ -55,6 +58,7 @@ services:
       - BUGSNAG_ENDPOINT
       - BUGSNAG_SESSION_ENDPOINT
       - BUGSNAG_CAPTURE_SESSIONS
+      - BUGSNAG_USE_CUSTOM_GUZZLE
     restart: "no"
     ports:
       - target: 8000

--- a/features/fixtures/laravel56/app/Providers/AppServiceProvider.php
+++ b/features/fixtures/laravel56/app/Providers/AppServiceProvider.php
@@ -23,6 +23,17 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        if (!getenv('BUGSNAG_USE_CUSTOM_GUZZLE')) {
+            return;
+        }
+
+        $this->app->singleton('bugsnag.guzzle', function ($app) {
+            $handler = \GuzzleHttp\HandlerStack::create();
+            $handler->push(\GuzzleHttp\Middleware::mapRequest(function ($request) {
+                return $request->withHeader('X-Custom-Guzzle', 'yes');
+            }));
+
+            return new \GuzzleHttp\Client(['handler' => $handler]);
+        });
     }
 }

--- a/features/fixtures/laravel56/composer.json.template
+++ b/features/fixtures/laravel56/composer.json.template
@@ -28,7 +28,8 @@
         "bugsnag/bugsnag-laravel": "4.0",
         "fideloper/proxy": "~4.0",
         "laravel/framework": "5.6.*",
-        "laravel/tinker": "~1.0"
+        "laravel/tinker": "~1.0",
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "filp/whoops": "~2.0",

--- a/features/fixtures/laravel58/app/Providers/AppServiceProvider.php
+++ b/features/fixtures/laravel58/app/Providers/AppServiceProvider.php
@@ -13,7 +13,18 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        if (!getenv('BUGSNAG_USE_CUSTOM_GUZZLE')) {
+            return;
+        }
+
+        $this->app->singleton('bugsnag.guzzle', function ($app) {
+            $handler = \GuzzleHttp\HandlerStack::create();
+            $handler->push(\GuzzleHttp\Middleware::mapRequest(function ($request) {
+                return $request->withHeader('X-Custom-Guzzle', 'yes');
+            }));
+
+            return new \GuzzleHttp\Client(['handler' => $handler]);
+        });
     }
 
     /**

--- a/features/fixtures/laravel58/composer.json.template
+++ b/features/fixtures/laravel58/composer.json.template
@@ -31,7 +31,8 @@
         "bugsnag/bugsnag-laravel": "4.0",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "5.8.*",
-        "laravel/tinker": "^1.0"
+        "laravel/tinker": "^1.0",
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "beyondcode/laravel-dump-server": "^1.0",

--- a/features/fixtures/laravel66/app/Providers/AppServiceProvider.php
+++ b/features/fixtures/laravel66/app/Providers/AppServiceProvider.php
@@ -13,7 +13,18 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        if (!getenv('BUGSNAG_USE_CUSTOM_GUZZLE')) {
+            return;
+        }
+
+        $this->app->singleton('bugsnag.guzzle', function ($app) {
+            $handler = \GuzzleHttp\HandlerStack::create();
+            $handler->push(\GuzzleHttp\Middleware::mapRequest(function ($request) {
+                return $request->withHeader('X-Custom-Guzzle', 'yes');
+            }));
+
+            return new \GuzzleHttp\Client(['handler' => $handler]);
+        });
     }
 
     /**

--- a/features/fixtures/laravel66/composer.json.template
+++ b/features/fixtures/laravel66/composer.json.template
@@ -31,7 +31,8 @@
         "bugsnag/bugsnag-laravel": "4.0",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "^6.2",
-        "laravel/tinker": "^2.0"
+        "laravel/tinker": "^2.0",
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "facade/ignition": "^1.4",

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -213,6 +213,10 @@ class BugsnagServiceProvider extends ServiceProvider
                 $client->setFilters($config['filters']);
             }
 
+            if (isset($config['endpoint'])) {
+                $client->setNotifyEndpoint($config['endpoint']);
+            }
+
             if ($this->isSessionTrackingAllowed($config)) {
                 $endpoint = isset($config['session_endpoint']) ? $config['session_endpoint'] : null;
                 $this->setupSessionTracking($client, $endpoint, $this->app->events);
@@ -281,7 +285,7 @@ class BugsnagServiceProvider extends ServiceProvider
             $options['proxy'] = $config['proxy'];
         }
 
-        return Client::makeGuzzle(isset($config['endpoint']) ? $config['endpoint'] : null, $options);
+        return Client::makeGuzzle(null, $options);
     }
 
     /**

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -266,6 +266,11 @@ class BugsnagServiceProvider extends ServiceProvider
      */
     protected function getGuzzle(array $config)
     {
+        // If a 'bugsnag.guzzle' instance exists in the container, use it
+        if ($this->app->bound('bugsnag.guzzle')) {
+            return $this->app->make('bugsnag.guzzle');
+        }
+
         $options = [];
 
         if (isset($config['proxy']) && $config['proxy']) {

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -419,6 +419,27 @@ class ServiceProviderTest extends AbstractTestCase
         }
     }
 
+    public function testItUsesGuzzleInstanceFromTheContainer()
+    {
+        $this->app->singleton('bugsnag.guzzle', function () {
+            /** @var \Mockery\MockInterface $mock */
+            $mock = Mockery::mock(\GuzzleHttp\ClientInterface::class);
+            $mock->shouldIgnoreMissing();
+
+            return $mock;
+        });
+
+        $expected = $this->app->make('bugsnag.guzzle');
+        $this->assertInstanceOf(\GuzzleHttp\ClientInterface::class, $expected);
+
+        $client = $this->app->make(Client::class);
+
+        $httpClient = $this->getProperty($client, 'http');
+        $actual = $this->getProperty($httpClient, 'guzzle');
+
+        $this->assertSame($expected, $actual);
+    }
+
     /**
      * Set the environment variable "$name" to the given value.
      *


### PR DESCRIPTION
## Goal

This PR adds support for fetching the Guzzle instance from the DI container using the `bugsnag.guzzle` alias. If `bugsnag.guzzle` does not exist, one will be created as before

## Changeset

- Fetch `bugsnag.guzzle` from the DI container
- Set notify endpoint if config is set; this is because we previously set this on the guzzle instance we create, but it's needed for custom guzzle instances too
- Don't set guzzle base URI via `makeGuzzle`; this isn't needed with the above change

The remaining changes are to tests

## Testing

- Unit test proves the right guzzle instance is used
- MR tests prove a custom guzzle instance is used by adding a header in a guzzle middleware
- Also [forced the unstable tests to run](https://github.com/bugsnag/bugsnag-laravel/runs/1419129784) to check they still pass