### PR TITLE
Allow overriding of the \Bugsnag\Client class

### DIFF
--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -305,4 +305,16 @@ return [
 
     'build_endpoint' => env('BUGSNAG_BUILD_ENDPOINT'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Override the Bugsnag\Client class
+    |--------------------------------------------------------------------------
+    |
+    | Sets a full class name to use as the Bugsnag client
+    |
+    | e.g. \MyCompany\Bugsnag\Client
+    |
+    */
+
+    'client_class' => env('BUGSNAG_CLIENT_CLASS'),
 ];


### PR DESCRIPTION
## Goal

Currently there is no way in the Laravel implementation to extend the \Bugsnag\Client class. This is useful for overriding the notify() method to send the calls asynchronously using the developers  asynchronous method of choice.

## Design

The best practice for this using dependency injection would require a large refactor to the library. This method was chosen to keep the configuration out of the code and in the config files, which is the preferred method in Laravel.

## Changeset

BugsnagServiceProvider was extended to add a getClient() method that checks for a class in the config file, and if it is not present, uses the default class.

## Testing

Manually tested the following cases:
Tested Bugsang::notify() with no config file and no .env setting: PASS - fallback to \Bugsnag\Client
Tested Bugsang::notify() with config file and no .env setting: PASS - fallback to \Bugsnag\Client
Tested Bugsang::notify() with config file and .env setting for missing class: PASS - fallback to \Bugsnag\Client
Tested Bugsang::notify() with config file and .env setting for valid class: PASS - uses overriden class
Tested Bugsang::notify() with config file and .env setting for invalid class: FAIL - 500 as expected