### PR TITLE
Prepare for MazeRunner v3.6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.5.1'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'
 gem "os", "~> 1.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.6.0'
 gem "os", "~> 1.0"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -42,3 +42,7 @@ end
 at_exit do
   FileUtils.rm_rf(VENDORED_LIB)
 end
+
+AfterConfiguration do |_config|
+  MazeRunner.config.enforce_bugsnag_integrity = false if MazeRunner.config.respond_to? :enforce_bugsnag_integrity=
+end


### PR DESCRIPTION
## Goal

Prepare for MazeRunner v3.6.0.

## Design

Once MazeRunner is next released, the build with this PR will just need to be re-run to pick up on it.