### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/maze-runner-tests.yml
+++ b/.github/workflows/maze-runner-tests.yml
@@ -19,7 +19,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install libcurl4-openssl-dev
-      run: sudo apt-get install libcurl4-openssl-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libcurl4-openssl-dev
 
     - name: install Ruby
       uses: actions/setup-ruby@v1

--- a/.github/workflows/unstable-version-tests.yml
+++ b/.github/workflows/unstable-version-tests.yml
@@ -43,7 +43,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install libcurl4-openssl-dev
-      run: sudo apt-get install libcurl4-openssl-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libcurl4-openssl-dev
 
     - name: install Ruby
       uses: actions/setup-ruby@v1


### PR DESCRIPTION
Installing libcurl (needed for one of Maze Runner's native dependencies) started failing over the weekend; an `apt-get update` before installing fixes it