### PR TITLE
Sync CI changes to master

### DIFF
--- a/.github/workflows/maze-runner-tests.yml
+++ b/.github/workflows/maze-runner-tests.yml
@@ -19,7 +19,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install libcurl4-openssl-dev
-      run: sudo apt-get install libcurl4-openssl-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libcurl4-openssl-dev
 
     - name: install Ruby
       uses: actions/setup-ruby@v1

--- a/.github/workflows/unstable-version-tests.yml
+++ b/.github/workflows/unstable-version-tests.yml
@@ -43,7 +43,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install libcurl4-openssl-dev
-      run: sudo apt-get install libcurl4-openssl-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libcurl4-openssl-dev
 
     - name: install Ruby
       uses: actions/setup-ruby@v1

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.5.1'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.6.0'
 gem "os", "~> 1.0"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -42,3 +42,7 @@ end
 at_exit do
   FileUtils.rm_rf(VENDORED_LIB)
 end
+
+AfterConfiguration do |_config|
+  MazeRunner.config.enforce_bugsnag_integrity = false if MazeRunner.config.respond_to? :enforce_bugsnag_integrity=
+end


### PR DESCRIPTION
## Goal

Recent PRs that make changes to tests need to be synced to master because the scheduled test runs always run against master