### PR TITLE
Allow the new ViewException class to be thrown in MazeRunner tests

### DIFF
--- a/features/unhandled_view.feature
+++ b/features/unhandled_view.feature
@@ -7,6 +7,7 @@ Scenario: Unhandled exceptions are delivered from views
   And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" matches one of the following:
     | ErrorException                              |
+    | Illuminate\\View\\ViewException             |
     | Facade\\Ignition\\Exceptions\\ViewException |
   And the exception "message" starts with "Unhandled exception (View: /app/resources/views/unhandledexception.blade.php)"
   And the event "metaData.request.httpMethod" equals "GET"
@@ -24,6 +25,7 @@ Scenario: Unhandled errors are delivered from views
   And the request is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" matches one of the following:
     | ErrorException                              |
+    | Illuminate\\View\\ViewException             |
     | Facade\\Ignition\\Exceptions\\ViewException |
   And the exception "message" equals "Call to undefined function foo() (View: /app/resources/views/unhandlederror.blade.php)"
   And the event "metaData.request.httpMethod" equals "GET"


### PR DESCRIPTION
## Goal

Laravel recently introduced an `Illuminate\View\ViewException` class which wraps errors thrown in views. Our tests need to allow this as an exception type or they will start failing with new Laravel versions