### PR TITLE
Fix missing 'ifconfig' on CI

### DIFF
--- a/.github/workflows/maze-runner-tests.yml
+++ b/.github/workflows/maze-runner-tests.yml
@@ -18,10 +18,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install libcurl4-openssl-dev
+    - name: Install libcurl4-openssl-dev and net-tools
       run: |
         sudo apt-get update
         sudo apt-get install libcurl4-openssl-dev
+        sudo apt-get install net-tools
 
     - name: install Ruby
       uses: actions/setup-ruby@v1

--- a/.github/workflows/maze-runner-tests.yml
+++ b/.github/workflows/maze-runner-tests.yml
@@ -25,12 +25,9 @@ jobs:
         sudo apt-get install net-tools
 
     - name: install Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-
-    - run: gem install bundler
-
-    - run: bundle install
+        bundler-cache: true
 
     - run: PHP_VERSION=${{ matrix.php-version }} LARAVEL_FIXTURE=${{ matrix.laravel-fixture }} bundle exec bugsnag-maze-runner

--- a/.github/workflows/unstable-version-tests.yml
+++ b/.github/workflows/unstable-version-tests.yml
@@ -49,13 +49,10 @@ jobs:
         sudo apt-get install net-tools
 
     - name: install Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-
-    - run: gem install bundler
-
-    - run: bundle install
+        bundler-cache: true
 
     - run: ./.ci/setup-laravel-dev-fixture.sh
 

--- a/.github/workflows/unstable-version-tests.yml
+++ b/.github/workflows/unstable-version-tests.yml
@@ -42,10 +42,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install libcurl4-openssl-dev
+    - name: Install libcurl4-openssl-dev and net-tools
       run: |
         sudo apt-get update
         sudo apt-get install libcurl4-openssl-dev
+        sudo apt-get install net-tools
 
     - name: install Ruby
       uses: actions/setup-ruby@v1


### PR DESCRIPTION
## Goal

The automatic update to Ubuntu 20 broke CI as it no longer has `ifconfig` by default, this is provided by the `net-tools` package. We use `ifconfig` to detect the IP the MazeRunner is running on so that the Docker container running Laravel can send reports to it

Also switched to the official `ruby/setup-ruby` action as [the GitHub provided one is deprecated](https://github.com/bugsnag/bugsnag-laravel/runs/2055387394?check_suite_focus=true#step:4:5)