### PR TITLE
Don't allow testbench 5.6 or testbench-core 3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "monolog/monolog": "^1.12|^2.0"
     },
     "require-dev": {
-        "graham-campbell/testbench": "^3.1|^4.0|^5.0",
+        "graham-campbell/testbench": "^3.1|^4.0|^5.0 < 5.6",
+        "graham-campbell/testbench-core": "< 3.3",
         "mockery/mockery": "^0.9.4|^1.3.1",
         "phpunit/phpunit": "^4.8.36|^6.3.1|^7.5.15|^8.3.5|^9.3.10"
     },


### PR DESCRIPTION
## Goal

[`AbstractTestCase::getServiceProviderClass` has an $app parameter](https://github.com/bugsnag/bugsnag-laravel/blob/be34470251bbd5867c42a6b50dffa3a070d5bd51/tests/AbstractTestCase.php#L17) which was removed in 5.6/3.3 of the testbench packages. This broke our test suite as we can't be compatible with both the old and new versions with the same file

Restricting the version range to avoid the new versions fixes this in the short term, but we'll likely need further changes to support these packages in the future as future versions of PHPUnit will eventually force us to update