### PR TITLE
Fix possible crash in the OOM bootstrapper

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -106,6 +106,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-version }}
+        coverage: none
 
     - run: composer validate
 

--- a/.github/workflows/unstable-version-tests.yml
+++ b/.github/workflows/unstable-version-tests.yml
@@ -20,6 +20,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-version }}
+        coverage: none
 
     - run: composer validate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug Fixes
+
+* Fix a possible crash in the OOM bootstrapper with an incomplete container
+  [#442](https://github.com/bugsnag/bugsnag-laravel/pull/442)
+
 ## 2.22.0 (2021-02-10)
 
 ### Enhancements

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
     <testsuites>
         <testsuite name="Bugsnag Laravel Test Suite">
             <directory suffix="Test.php">./tests</directory>
+            <directory suffix=".phpt">./tests/phpt</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/phpt/oom_bootstrapper_should_not_crash_when_bugsnag_is_missing.phpt
+++ b/tests/phpt/oom_bootstrapper_should_not_crash_when_bugsnag_is_missing.phpt
@@ -1,0 +1,47 @@
+--TEST--
+The OomBootstrapper should not crash when bugsnag is not in the DI container
+--FILE--
+<?php
+
+use Bugsnag\BugsnagLaravel\OomBootstrapper;
+
+function app($alias = null) {
+    echo "'app' was called!\n";
+
+    if ($alias === 'bugsnag') {
+        return null;
+    }
+
+    if ($alias !== null) {
+        throw new UnexpectedValueException("Unknown alias '{$alias}' given");
+    }
+
+    throw new BadFunctionCallException("This fake 'app' should always be called with an alias");
+}
+
+require __DIR__.'/../../src/OomBootstrapper.php';
+
+(new OomBootstrapper())->bootstrap();
+
+ini_set('memory_limit', '5M');
+
+$i = 0;
+
+gc_disable();
+
+while ($i++ < 12345678) {
+    $a = new stdClass;
+    $a->b = $a;
+}
+
+echo "No OOM!\n";
+?>
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION < 7) {
+    echo "SKIP - PHP 5 does not run OOM in this test";
+}
+?>
+--EXPECTF--
+Fatal error: Allowed memory size of %d bytes exhausted (tried to allocate %d bytes) in %s on line %d
+'app' was called!

--- a/tests/phpt/oom_bootstrapper_should_not_crash_when_bugsnag_is_present.phpt
+++ b/tests/phpt/oom_bootstrapper_should_not_crash_when_bugsnag_is_present.phpt
@@ -1,0 +1,59 @@
+--TEST--
+The OomBootstrapper should not crash when bugsnag is in the DI container
+--FILE--
+<?php
+
+use Bugsnag\BugsnagLaravel\OomBootstrapper;
+
+class FakeClient
+{
+    public function getMemoryLimitIncrease()
+    {
+        echo "'getMemoryLimitIncrease' was called!\n";
+
+        return 12345;
+    }
+}
+
+function app($alias = null) {
+    echo "'app' was called!\n";
+
+    if ($alias === 'bugsnag') {
+        return new FakeClient();
+    }
+
+    if ($alias !== null) {
+        throw new UnexpectedValueException("Unknown alias '{$alias}' given");
+    }
+
+    throw new BadFunctionCallException("This fake 'app' should always be called with an alias");
+}
+
+require __DIR__.'/../../src/OomBootstrapper.php';
+
+(new OomBootstrapper())->bootstrap();
+
+ini_set('memory_limit', '5M');
+
+$i = 0;
+
+gc_disable();
+
+while ($i++ < 12345678) {
+    $a = new stdClass;
+    $a->b = $a;
+}
+
+echo "No OOM!\n";
+?>
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION < 7) {
+    echo "SKIP - PHP 5 does not run OOM in this test";
+}
+?>
+--EXPECTF--
+Fatal error: Allowed memory size of %d bytes exhausted (tried to allocate %d bytes) in %s on line %d
+'app' was called!
+'getMemoryLimitIncrease' was called!
+'getMemoryLimitIncrease' was called!


### PR DESCRIPTION
## Goal

This PR fixes a possible crash in `OomBootstrapper`, which happens when Bugsnag is not in the DI container. This would typically only be in situations where the container that's being used doesn't contain every service, i.e. when running unit tests

I've added some simple tests that check specifically for this crash — the functionality of the `OomBootstrapper` is already tested with MazeRunner