### PR TITLE
Fix unstable version tests

### DIFF
--- a/.ci/setup-laravel-dev-fixture.sh
+++ b/.ci/setup-laravel-dev-fixture.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env sh
 
-set -e
+set -ex
+
+if [ $# -eq 0 ]; then
+    printf "Error: No Laravel version given\n\n"
+    printf "Usage:\n"
+    printf "  $ %s <version>\n\n" "$0"
+    printf "Examples:\n"
+    printf "  $ %s 8.0.0\n" "$0"
+    printf "  $ %s 8.x-dev as 8\n" "$0"
+
+    exit 64
+fi
+
+LARAVEL_VERSION=$1
 
 cd features/fixtures
 
@@ -12,7 +25,7 @@ composer create-project laravel/laravel laravel-latest --no-dev
 
 cd laravel-latest
 
-composer require 'laravel/framework:dev-master as 8' --update-with-dependencies --no-update
+composer require laravel/framework:"$LARAVEL_VERSION" --update-with-dependencies --no-update
 composer config repositories.bugsnag-laravel '{ "type": "path", "url": "../../../", "options": { "symlink": false } }'
 composer require bugsnag/bugsnag-laravel '*' --no-update
 

--- a/.github/workflows/unstable-version-tests.yml
+++ b/.github/workflows/unstable-version-tests.yml
@@ -37,8 +37,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [7.4]
+        php-version: [8.0]
         laravel-fixture: [laravel-latest]
+        laravel-version: ['8.x-dev as 8'] #, 'dev-master as 8'] # disabled pending package updates in Laravel's skeleton app (PLAT-7040)
 
     steps:
     - uses: actions/checkout@v2
@@ -55,6 +56,6 @@ jobs:
         ruby-version: 2.7
         bundler-cache: true
 
-    - run: ./.ci/setup-laravel-dev-fixture.sh
+    - run: ./.ci/setup-laravel-dev-fixture.sh ${{ matrix.laravel-version }}
 
     - run: PHP_VERSION=${{ matrix.php-version }} LARAVEL_FIXTURE=${{ matrix.laravel-fixture }} bundle exec bugsnag-maze-runner

--- a/.github/workflows/unstable-version-tests.yml
+++ b/.github/workflows/unstable-version-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [7.4]
+        php-version: [8.0]
         laravel-version: ['8.x-dev as 8', 'dev-master as 8']
 
     steps:


### PR DESCRIPTION
## Goal

The "unstable tests" that run against 8.x and master branch of Laravel are current failing because of dependency issues:

- Laravel's master branch now requires PHP 8
- The Laravel skeleton app is not yet compatible with Laravel's master as they have updated to use Symfony 6 components

This PR bumps the PHP version these tests use to 8 to allow the unit tests to run. I've had to disable the MR tests against Laravel master but I've made this run against the 8.x branch instead. This still gives most of the benefit as Laravel 9 won't be released until early next year so we have plenty of time to re-enable these tests before it releases (PLAT-7040)

See https://github.com/bugsnag/bugsnag-laravel/runs/3136097461 for a successful test run as these tests don't run on push or PRs

This PR is intentionally going into master as scheduled GH Actions only run on the master branch