### PR TITLE
Reduce available memory in OOM tests on CI

### DIFF
--- a/.ci/patches/web-routes.patch
+++ b/.ci/patches/web-routes.patch
@@ -74,7 +74,7 @@ index b130397..0c687ad 100644
 +});
 +
 +Route::get('/oom/small', function () {
-+    ini_set('memory_limit', memory_get_usage() + (1024 * 1024 * 5));
++    ini_set('memory_limit', memory_get_usage() + (1024 * 1024 * 2));
 +    ini_set('display_errors', true);
 +
 +    $i = 0;

--- a/features/fixtures/laravel56/routes/web.php
+++ b/features/fixtures/laravel56/routes/web.php
@@ -77,7 +77,7 @@ Route::get('/oom/big', function () {
 });
 
 Route::get('/oom/small', function () {
-    ini_set('memory_limit', memory_get_usage() + (1024 * 1024 * 5));
+    ini_set('memory_limit', memory_get_usage() + (1024 * 1024 * 2));
     ini_set('display_errors', true);
 
     $i = 0;

--- a/features/fixtures/laravel58/routes/web.php
+++ b/features/fixtures/laravel58/routes/web.php
@@ -77,7 +77,7 @@ Route::get('/oom/big', function () {
 });
 
 Route::get('/oom/small', function () {
-    ini_set('memory_limit', memory_get_usage() + (1024 * 1024 * 5));
+    ini_set('memory_limit', memory_get_usage() + (1024 * 1024 * 2));
     ini_set('display_errors', true);
 
     $i = 0;

--- a/features/fixtures/laravel66/routes/web.php
+++ b/features/fixtures/laravel66/routes/web.php
@@ -77,7 +77,7 @@ Route::get('/oom/big', function () {
 });
 
 Route::get('/oom/small', function () {
-    ini_set('memory_limit', memory_get_usage() + (1024 * 1024 * 5));
+    ini_set('memory_limit', memory_get_usage() + (1024 * 1024 * 2));
     ini_set('display_errors', true);
 
     $i = 0;


### PR DESCRIPTION
## Goal

The "small OOM without the OOM bootstrapper" Maze Runner test started failing over the weekend on Laravel 5.8 because it started sending an event for the OOM. This test exists mostly to notify us if Laravel changes something that makes the OOM bootstrapper unnecessary, so it's not really a problem if it fails in this way because the library is still working correctly

I haven't been able to figure out exactly what changed to cause this failure, but it can be fixed by reducing the amount of memory the fixtures can use. It's not particularly important to figure out the root cause because any number of things could cause Laravel to consume less memory, which could cause this failure. Reducing the available memory should also reduce the chance of this failure happening again

This PR is going into master because the scheduled tests run there