### PR TITLE
Revert memory limit decrease in overnight tests

### DIFF
--- a/.ci/patches/web-routes.patch
+++ b/.ci/patches/web-routes.patch
@@ -74,7 +74,7 @@ index b130397..0c687ad 100644
 +});
 +
 +Route::get('/oom/small', function () {
-+    ini_set('memory_limit', memory_get_usage() + (1024 * 1024 * 2));
++    ini_set('memory_limit', memory_get_usage() + (1024 * 1024 * 5));
 +    ini_set('display_errors', true);
 +
 +    $i = 0;


### PR DESCRIPTION
## Goal

Reverts the memory limit increase from https://github.com/bugsnag/bugsnag-laravel/pull/455 in the laravel-latest fixture

For some reason in the laravel-latest fixture, a 2 MiB increase isn't OK — it fails because it's already using more memory than this (which is confusing in itself!)

There's no real need for all of the fixtures to have the same memory limit in these tests, so we can safely revert it in this fixture specifically and the exact memory limit really isn't important (so long as it runs OOM)

See https://github.com/bugsnag/bugsnag-laravel/runs/3567592319 for a successful run after this change

Targeting master as scheduled tests only run from there