### PR TITLE
Make app->config->get() always return an array

### DIFF
--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -47,7 +47,7 @@ class BugsnagServiceProvider extends ServiceProvider
     {
         $this->setupConfig($this->app);
 
-        $this->setupEvents($this->app->events, $this->app->config->get('bugsnag'));
+        $this->setupEvents($this->app->events, $this->app->config->get('bugsnag', []));
 
         $this->setupQueue($this->app->queue);
 


### PR DESCRIPTION
## Goal

When `config/bugsnag.php` is missing it causes an error

```
Argument 2 passed to Bugsnag\BugsnagLaravel\BugsnagServiceProvider::setupEvents()
must be of the type array, null given
```

@imjoehaines