### PR TITLE
Specify exact PHP versions instead of >=

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": "^5.5|^5.6|^7.0|^7.1|^7.2|^7.3|^7.4|^8.0",
         "bugsnag/bugsnag": "^3.26.0",
         "bugsnag/bugsnag-psr-logger": "^1.4",
         "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0",


### PR DESCRIPTION
## Goal

It's safer to specify exact PHP versions rather than using `>=` because what's compatible with php `8.0` can be unsupported with php `8.1`

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->