### PR TITLE
Allow installing Bugsnag PSR Logger v2

### DIFF
--- a/.github/workflows/maze-runner-tests.yml
+++ b/.github/workflows/maze-runner-tests.yml
@@ -12,8 +12,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [7.4]
-        laravel-fixture: [laravel56, laravel58, laravel66, laravel8, lumen8]
+        include:
+          - php-version: '7.4'
+            laravel-fixture: laravel56
+          - php-version: '7.4'
+            laravel-fixture: laravel58
+          - php-version: '7.4'
+            laravel-fixture: laravel66
+          - php-version: '8.0'
+            laravel-fixture: laravel8
+          - php-version: '8.0'
+            laravel-fixture: lumen8
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Allow installing Bugsnag PSR Logger v2. This adds support for PSR Log v3
+  [#471](https://github.com/bugsnag/bugsnag-laravel/pull/471)
+
 ## 2.22.2 (2021-09-06)
 
 ### Bug Fixes

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.5",
         "bugsnag/bugsnag": "^3.26.0",
-        "bugsnag/bugsnag-psr-logger": "^1.4",
+        "bugsnag/bugsnag-psr-logger": "^1.4|^2.0",
         "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0",
         "illuminate/support": "^5.0|^6.0|^7.0|^8.0",
         "monolog/monolog": "^1.12|^2.0"


### PR DESCRIPTION
## Goal

This PR allows installing [Bugsnag PSR Logger v2](https://github.com/bugsnag/bugsnag-psr-logger/releases/tag/v2.0.0), which adds support for PSR Log v3

This is important for Laravel v9 support, as it will be the first version of Laravel to [allow PSR Log v3](https://github.com/laravel/framework/blob/7bd18cfaf3999812cd804e9ed73803c8a8a98104/composer.json#L30)

## Testing

To improve the test coverage of this, I've moved our Laravel & Lumen v8 Maze Runner tests to run on PHP 8.0. This allows them to use Bugsnag PSR Logger v2 as it requires PHP 8.0+

This can be seen in the unit tests — [on PHP 7.4 Bugsnag PSR Logger v1 is used](https://github.com/bugsnag/bugsnag-laravel/runs/4899376548?check_suite_focus=true#step:6:10), but [on PHP 8.0 Bugsnag PSR Logger v2 is used](https://github.com/bugsnag/bugsnag-laravel/runs/4899376797?check_suite_focus=true#step:6:10)