### PR TITLE
Prepare for running unit tests against Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     },
     "require-dev": {
         "orchestra/testbench": "^3.1|^4.0|^5.0|^6.0|^7.0",
-        "mockery/mockery": "^0.9.4|^1.3.1",
         "phpunit/phpunit": "^4.8.36|^6.3.1|^7.5.15|^8.3.5|^9.3.10"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "monolog/monolog": "^1.12|^2.0"
     },
     "require-dev": {
-        "graham-campbell/testbench": "^3.1|^4.0|^5.0 < 5.6",
-        "graham-campbell/testbench-core": "< 3.3",
+        "orchestra/testbench": "^3.1|^4.0|^5.0|^6.0|^7.0",
         "mockery/mockery": "^0.9.4|^1.3.1",
         "phpunit/phpunit": "^4.8.36|^6.3.1|^7.5.15|^8.3.5|^9.3.10"
     },

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -3,13 +3,10 @@
 namespace Bugsnag\BugsnagLaravel\Tests;
 
 use Bugsnag\BugsnagLaravel\BugsnagServiceProvider;
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Orchestra\Testbench\TestCase;
 
 abstract class AbstractTestCase extends TestCase
 {
-    use MockeryPHPUnitIntegration;
-
     /**
      * Get the service provider class.
      *

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -3,20 +3,25 @@
 namespace Bugsnag\BugsnagLaravel\Tests;
 
 use Bugsnag\BugsnagLaravel\BugsnagServiceProvider;
-use GrahamCampbell\TestBench\AbstractPackageTestCase;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Orchestra\Testbench\TestCase;
 
-abstract class AbstractTestCase extends AbstractPackageTestCase
+abstract class AbstractTestCase extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * Get the service provider class.
      *
      * @param \Illuminate\Contracts\Foundation\Application $app
      *
-     * @return string
+     * @return array<string>
      */
-    protected function getServiceProviderClass($app)
+    protected function getPackageProviders($app)
     {
-        return BugsnagServiceProvider::class;
+        return [
+            BugsnagServiceProvider::class,
+        ];
     }
 
     /**
@@ -34,5 +39,49 @@ abstract class AbstractTestCase extends AbstractPackageTestCase
         };
 
         return call_user_func($propertyAccessor->bindTo($object, $object), $property);
+    }
+
+    /**
+     * Set the environment variable "$name" to the given value.
+     *
+     * @param string $name
+     * @param string $value
+     *
+     * @return void
+     */
+    protected function setEnvironmentVariable($name, $value)
+    {
+        // Workaround a PHP 5 parser issue - '$app::VERSION' is valid but
+        // '$this->app::VERSION' is not
+        $app = $this->app;
+
+        // Laravel >= 5.8.0 uses "$_ENV" instead of "putenv" by default
+        if (version_compare($app::VERSION, '5.8.0', '>=')) {
+            $_ENV[$name] = $value;
+        } else {
+            putenv("{$name}={$value}");
+        }
+    }
+
+    /**
+     * Remove the environment variable "$name" from the environment.
+     *
+     * @param string $name
+     * @param string $value
+     *
+     * @return void
+     */
+    protected function removeEnvironmentVariable($name)
+    {
+        // Workaround a PHP 5 parser issue - '$app::VERSION' is valid but
+        // '$this->app::VERSION' is not
+        $app = $this->app;
+
+        // Laravel >= 5.8.0 uses "$_ENV" instead of "putenv" by default
+        if (version_compare($app::VERSION, '5.8.0', '>=')) {
+            unset($_ENV[$name]);
+        } else {
+            putenv("{$name}");
+        }
     }
 }

--- a/tests/Facades/BugsnagTest.php
+++ b/tests/Facades/BugsnagTest.php
@@ -5,39 +5,34 @@ namespace Bugsnag\BugsnagLaravel\Tests\Facades;
 use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
 use Bugsnag\BugsnagLaravel\Tests\AbstractTestCase;
 use Bugsnag\Client;
-use GrahamCampbell\TestBenchCore\FacadeTrait;
+use Illuminate\Support\Facades\Facade;
 
 class BugsnagTest extends AbstractTestCase
 {
-    use FacadeTrait;
-
-    /**
-     * Get the facade accessor.
-     *
-     * @return string
-     */
-    protected function getFacadeAccessor()
+    public function testIsFacade()
     {
-        return 'bugsnag';
+        $this->assertInstanceOf(Facade::class, new Bugsnag());
     }
 
-    /**
-     * Get the facade class.
-     *
-     * @return string
-     */
-    protected function getFacadeClass()
+    public function testIsFacadeForBugsnagClient()
     {
-        return Bugsnag::class;
+        $root = Bugsnag::getFacadeRoot();
+
+        $this->assertInstanceOf(Client::class, $root);
+        $this->assertSame($root, $this->app->make('bugsnag'));
     }
 
-    /**
-     * Get the facade root.
-     *
-     * @return string
-     */
-    protected function getFacadeRoot()
+    public function testItCanCallClientMethods()
     {
-        return Client::class;
+        Bugsnag::setDiscardClasses(['Example']);
+        $this->assertSame(['Example'], Bugsnag::getDiscardClasses());
+
+        Bugsnag::setNotifyEndpoint('https://example.com');
+        $this->assertSame('https://example.com', Bugsnag::getNotifyEndpoint());
+
+        $client = $this->app->make('bugsnag');
+
+        $this->assertSame(['Example'], $client->getDiscardClasses());
+        $this->assertSame('https://example.com', $client->getNotifyEndpoint());
     }
 }

--- a/tests/Request/LaravelRequestTest.php
+++ b/tests/Request/LaravelRequestTest.php
@@ -1,8 +1,8 @@
 <?php
 
-// stub out php_sapi_name in the Illumnate\Foundation namespace so we can
-// change its behaviour. Some Laravel versions use this to determine if
-// the app is running in a console
+// stub out php_sapi_name in the Illumnate\Foundation namespace so we can change
+// its behaviour. Laravel 5.0 - 5.8 use this to determine if the app is running
+// in a console (6.0+ use an environment variable or the PHP_SAPI constant)
 
 namespace Illuminate\Foundation;
 

--- a/tests/Request/LaravelRequestTest.php
+++ b/tests/Request/LaravelRequestTest.php
@@ -1,31 +1,32 @@
 <?php
 
+// stub out php_sapi_name in the Illumnate\Foundation namespace so we can
+// change its behaviour. Some Laravel versions use this to determine if
+// the app is running in a console
+
+namespace Illuminate\Foundation;
+
+use Bugsnag\BugsnagLaravel\Tests\Stubs\PhpSapiNameStub;
+
+function php_sapi_name()
+{
+    return PhpSapiNameStub::get();
+}
+
 namespace Bugsnag\BugsnagLaravel\Tests\Request;
 
 use Bugsnag\BugsnagLaravel\Request\LaravelRequest;
 use Bugsnag\BugsnagLaravel\Request\LaravelResolver;
+use Bugsnag\BugsnagLaravel\Tests\AbstractTestCase;
+use Bugsnag\BugsnagLaravel\Tests\Stubs\PhpSapiNameStub;
 use Bugsnag\Request\ConsoleRequest;
 use Bugsnag\Request\RequestInterface;
-use GrahamCampbell\TestBenchCore\MockeryTrait;
-use Illuminate\Foundation\Application;
-use Illuminate\Http\Request;
-use Mockery;
-use PHPUnit_Framework_TestCase as TestCase;
 
-class LaravelRequestTest extends TestCase
+class LaravelRequestTest extends AbstractTestCase
 {
-    use MockeryTrait;
-
     public function testCanResolveConsoleRequest()
     {
-        $request = Mockery::mock(Request::class);
-        $app = Mockery::mock(Application::class);
-
-        $app->shouldReceive('runningInConsole')->once()->andReturn(true);
-        $app->shouldReceive('make')->once()->with(Request::class)->andReturn($request);
-        $request->shouldReceive('server')->once()->with('argv', [])->andReturn('test mock console command');
-
-        $resolver = new LaravelResolver($app);
+        $resolver = new LaravelResolver($this->app);
         $result = $resolver->resolve();
 
         $this->assertInstanceOf(RequestInterface::class, $result);
@@ -34,14 +35,25 @@ class LaravelRequestTest extends TestCase
 
     public function testCanResolveLaravelRequest()
     {
-        $resolver = new LaravelResolver($app = Mockery::mock(Application::class));
+        try {
+            // different versions of Laravel use slightly different mechanisms
+            // to determine if the app is 'runningInConsole'
+            PhpSapiNameStub::set('not cli');
+            $this->setEnvironmentVariable('APP_RUNNING_IN_CONSOLE', false);
 
-        $app->shouldReceive('runningInConsole')->once()->andReturn(false);
-        $app->shouldReceive('make')->once()->with(Request::class)->andReturn($request = Mockery::mock(Request::class));
+            // At this point we already have a Laravel app loaded so the environment
+            // variable won't be picked up. Refreshing the application forces
+            // the config to re-load
+            $this->refreshApplication();
 
-        $request = $resolver->resolve();
+            $resolver = new LaravelResolver($this->app);
+            $result = $resolver->resolve();
 
-        $this->assertInstanceOf(RequestInterface::class, $request);
-        $this->assertInstanceOf(LaravelRequest::class, $request);
+            $this->assertInstanceOf(RequestInterface::class, $result);
+            $this->assertInstanceOf(LaravelRequest::class, $result);
+        } finally {
+            PhpSapiNameStub::reset();
+            $this->removeEnvironmentVariable('APP_RUNNING_IN_CONSOLE');
+        }
     }
 }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -2,21 +2,22 @@
 
 namespace Bugsnag\BugsnagLaravel\Tests;
 
+use Bugsnag\BugsnagLaravel\BugsnagServiceProvider;
 use Bugsnag\BugsnagLaravel\LaravelLogger;
 use Bugsnag\BugsnagLaravel\MultiLogger;
 use Bugsnag\BugsnagLaravel\Queue\Tracker;
+use Bugsnag\BugsnagLaravel\Tests\Stubs\Injectee;
+use Bugsnag\BugsnagLaravel\Tests\Stubs\InjecteeWithLogInterface;
 use Bugsnag\Client;
 use Bugsnag\PsrLogger\BugsnagLogger;
 use Bugsnag\PsrLogger\MultiLogger as BaseMultiLogger;
-use GrahamCampbell\TestBenchCore\ServiceProviderTrait;
 use Illuminate\Contracts\Logging\Log;
 use Illuminate\Foundation\Application;
+use Illuminate\Support\ServiceProvider;
 use Mockery;
 
 class ServiceProviderTest extends AbstractTestCase
 {
-    use ServiceProviderTrait;
-
     /**
      * An Application instance provided by the parent test case.
      *
@@ -24,24 +25,75 @@ class ServiceProviderTest extends AbstractTestCase
      */
     protected $app;
 
-    public function testClientIsInjectable()
+    public function testItIsAServiceProvider()
     {
-        $this->assertIsInjectable(Client::class);
+        $serviceProvider = $this->app->getProvider(BugsnagServiceProvider::class);
+
+        $this->assertInstanceOf(ServiceProvider::class, $serviceProvider);
     }
 
-    public function testJobTrackerIsInjectable()
+    public function testItProvidesAValidListOfServices()
     {
-        $this->assertIsInjectable(Tracker::class);
+        $serviceProvider = $this->app->getProvider(BugsnagServiceProvider::class);
+        $provides = $serviceProvider->provides();
+
+        // ensure there's at least one provided service
+        $this->assertNotEmpty($provides);
+
+        foreach ($provides as $serviceId) {
+            // assert this service exists in the container
+            $this->assertTrue(
+                $this->app->bound($serviceId),
+                "Expected the ID '{$serviceId}' to be bound in the DI container"
+            );
+
+            // ensure the service can be resolved
+            $this->app->make($serviceId);
+        }
     }
 
-    public function testMultiLoggerIsInjectable()
+    /**
+     * @dataProvider serviceAliasProvider
+     */
+    public function testItRegistersAnAliasForEachService($serviceId, $alias)
     {
-        $this->assertIsInjectable(interface_exists(Log::class) ? MultiLogger::class : BaseMultiLogger::class);
+        $this->assertTrue(
+            $this->app->bound($serviceId),
+            "Expected the ID '{$serviceId}' to be bound in the DI container"
+        );
+
+        $this->assertTrue(
+            $this->app->bound($alias),
+            "Expected the ID '{$alias}' to be bound in the DI container"
+        );
+
+        $service = $this->app->make($serviceId);
+        $aliasInstance = $this->app->make($alias);
+
+        $this->assertSame($service, $aliasInstance);
     }
 
-    public function testBugsnagLoggerIsInjectable()
+    public function serviceAliasProvider()
     {
-        $this->assertIsInjectable(interface_exists(Log::class) ? LaravelLogger::class : BugsnagLogger::class);
+        return [
+            'bugsnag' => ['bugsnag', Client::class],
+            'bugsnag.tracker' => ['bugsnag.tracker', Tracker::class],
+            'bugsnag.logger' => ['bugsnag.logger', interface_exists(Log::class) ? LaravelLogger::class : BugsnagLogger::class],
+            'bugsnag.multi' => ['bugsnag.multi', interface_exists(Log::class) ? MultiLogger::class : BaseMultiLogger::class],
+        ];
+    }
+
+    public function testServicesAreInjectable()
+    {
+        if (interface_exists(Log::class)) {
+            $injectee = InjecteeWithLogInterface::class;
+        } else {
+            $injectee = Injectee::class;
+        }
+
+        $service = $this->app->make($injectee);
+
+        $this->assertTrue($service->wasConstructed());
     }
 
     /**
@@ -131,8 +183,6 @@ class ServiceProviderTest extends AbstractTestCase
         $client = $this->app->make(Client::class);
 
         $this->assertInstanceOf(Client::class, $client);
-
-        $appRoot = $this->app->path();
 
         /** @var Client $client */
         $config = $client->getConfig();
@@ -274,8 +324,7 @@ class ServiceProviderTest extends AbstractTestCase
     public function testCorrectLoggerClassesReturned()
     {
         $app = Mockery::mock(Application::class);
-        $providerClass = $this->getServiceProviderClass($app);
-        $provider = new $providerClass($app);
+        $provider = new BugsnagServiceProvider($app);
 
         $loggerClass = interface_exists(Log::class) ? LaravelLogger::class : BugsnagLogger::class;
         $multiLoggerClass = interface_exists(Log::class) ? MultiLogger::class : BaseMultiLogger::class;
@@ -473,49 +522,5 @@ class ServiceProviderTest extends AbstractTestCase
             [1234],
             [1024 * 1024 * 20],
         ];
-    }
-
-    /**
-     * Set the environment variable "$name" to the given value.
-     *
-     * @param string $name
-     * @param string $value
-     *
-     * @return void
-     */
-    private function setEnvironmentVariable($name, $value)
-    {
-        // Workaround a PHP 5 parser issue - '$app::VERSION' is valid but
-        // '$this->app::VERSION' is not
-        $app = $this->app;
-
-        // Laravel >= 5.8.0 uses "$_ENV" instead of "putenv" by default
-        if (version_compare($app::VERSION, '5.8.0', '>=')) {
-            $_ENV[$name] = $value;
-        } else {
-            putenv("{$name}={$value}");
-        }
-    }
-
-    /**
-     * Remove the environment variable "$name" from the environment.
-     *
-     * @param string $name
-     * @param string $value
-     *
-     * @return void
-     */
-    private function removeEnvironmentVariable($name)
-    {
-        // Workaround a PHP 5 parser issue - '$app::VERSION' is valid but
-        // '$this->app::VERSION' is not
-        $app = $this->app;
-
-        // Laravel >= 5.8.0 uses "$_ENV" instead of "putenv" by default
-        if (version_compare($app::VERSION, '5.8.0', '>=')) {
-            unset($_ENV[$name]);
-        } else {
-            putenv("{$name}");
-        }
     }
 }

--- a/tests/Stubs/Injectee.php
+++ b/tests/Stubs/Injectee.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Bugsnag\BugsnagLaravel\Tests\Stubs;
+
+use Bugsnag\BugsnagLaravel\Queue\Tracker;
+use Bugsnag\Client;
+use Bugsnag\PsrLogger\BugsnagLogger;
+use Bugsnag\PsrLogger\MultiLogger;
+
+class Injectee
+{
+    private $client;
+    private $tracker;
+    private $multiLogger;
+    private $bugsnagLogger;
+
+    public function __construct(
+        Client $client,
+        Tracker $tracker,
+        MultiLogger $multiLogger,
+        BugsnagLogger $bugsnagLogger
+    ) {
+        $this->client = $client;
+        $this->tracker = $tracker;
+        $this->multiLogger = $multiLogger;
+        $this->bugsnagLogger = $bugsnagLogger;
+    }
+
+    public function wasConstructed()
+    {
+        return $this->client instanceof Client
+            && $this->tracker instanceof Tracker
+            && $this->multiLogger instanceof MultiLogger
+            && $this->bugsnagLogger instanceof BugsnagLogger;
+    }
+}

--- a/tests/Stubs/InjecteeWithLogInterface.php
+++ b/tests/Stubs/InjecteeWithLogInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Bugsnag\BugsnagLaravel\Tests\Stubs;
+
+use Bugsnag\BugsnagLaravel\LaravelLogger;
+use Bugsnag\BugsnagLaravel\MultiLogger;
+use Bugsnag\BugsnagLaravel\Queue\Tracker;
+use Bugsnag\Client;
+
+class InjecteeWithLogInterface
+{
+    private $client;
+    private $tracker;
+    private $multiLogger;
+    private $laravelLogger;
+
+    public function __construct(
+        Client $client,
+        Tracker $tracker,
+        MultiLogger $multiLogger,
+        LaravelLogger $laravelLogger
+    ) {
+        $this->client = $client;
+        $this->tracker = $tracker;
+        $this->multiLogger = $multiLogger;
+        $this->laravelLogger = $laravelLogger;
+    }
+
+    public function wasConstructed()
+    {
+        return $this->client instanceof Client
+            && $this->tracker instanceof Tracker
+            && $this->multiLogger instanceof MultiLogger
+            && $this->laravelLogger instanceof LaravelLogger;
+    }
+}

--- a/tests/Stubs/PhpSapiNameStub.php
+++ b/tests/Stubs/PhpSapiNameStub.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Bugsnag\BugsnagLaravel\Tests\Stubs;
+
+class PhpSapiNameStub
+{
+    private static $name = 'cli';
+
+    public static function get()
+    {
+        return self::$name;
+    }
+
+    public static function set($name)
+    {
+        self::$name = $name;
+    }
+
+    public static function reset()
+    {
+        self::$name = 'cli';
+    }
+}


### PR DESCRIPTION
## Goal

Currently we have a version restriction on `graham-campbell/testbench` & `graham-campbell/testbench-core` due to a BC break that makes the newer versions incompatible with our test suite (see https://github.com/bugsnag/bugsnag-laravel/pull/441 / https://github.com/GrahamCampbell/Laravel-TestBench/issues/28 / https://github.com/GrahamCampbell/Laravel-TestBench-Core/issues/12):

https://github.com/bugsnag/bugsnag-laravel/blob/b8eb1dce72eb8b2e7cde8118b0e002389a22deda/composer.json#L22-L23

This blocks testing against the upcoming Laravel 9 release because Laravel 9 support was added in the latest release of both packages

Instead of trying to workaround the BC break (e.g. with a dynamic class declaration), I've opted to depend directly on `orchestra/testbench` instead. This is the package that provides most of the functionality for testing against a Laravel app, so it wasn't too difficult to migrate our test suite over. I've added some new tests to cover the things that were being tested for us by the old dependencies

I also noticed we were only using Mockery in a couple of tests, so I've rewritten those tests to avoid mocking and removed Mockery as a direct dependency because we don't use it anymore (`orchestra/testbench` still depends on Mockery, so it's still a transitive dependency)