### PR TITLE
Allow installation on Laravel 9 projects

### DIFF
--- a/.github/workflows/maze-runner-tests.yml
+++ b/.github/workflows/maze-runner-tests.yml
@@ -41,10 +41,7 @@ jobs:
         ruby-version: '2.7'
         bundler-cache: true
 
-    # temporarily edit composer.json to allow Laravel 9 components
-    - run: |
-        sed -i 's/\^8.0/\^8.0\|\^9.0/g' composer.json
-        bundle exec bugsnag-maze-runner
+    - run: bundle exec bugsnag-maze-runner
       env:
         PHP_VERSION: ${{ matrix.php-version }}
         LARAVEL_FIXTURE: ${{ matrix.laravel-fixture }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -100,6 +100,10 @@ jobs:
             laravel-version: '^8.12.0'
           - php-version: '8.1'
             laravel-version: '^8.12.0'
+          - php-version: '8.0'
+            laravel-version: '9.*'
+          - php-version: '8.1'
+            laravel-version: '9.*'
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Changelog
 
 ### Enhancements
 
+* Allow installation on Laravel 9 projects
+  [jdanio](https://github.com/jdanio)
+  [#470](https://github.com/bugsnag/bugsnag-laravel/pull/470)
+  [#477](https://github.com/bugsnag/bugsnag-laravel/pull/477)
 * Allow installing Bugsnag PSR Logger v2. This adds support for PSR Log v3
   [#471](https://github.com/bugsnag/bugsnag-laravel/pull/471)
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "bugsnag/bugsnag": "^3.26.0",
+        "bugsnag/bugsnag": "^3.27.0",
         "bugsnag/bugsnag-psr-logger": "^1.4|^2.0",
         "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0",
         "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0",

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "php": ">=5.5",
         "bugsnag/bugsnag": "^3.26.0",
         "bugsnag/bugsnag-psr-logger": "^1.4|^2.0",
-        "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0",
-        "illuminate/support": "^5.0|^6.0|^7.0|^8.0",
+        "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0",
         "monolog/monolog": "^1.12|^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Goal

https://github.com/bugsnag/bugsnag-laravel/pull/470 ended up with a conflict, so I've rebased it in this PR. I've also:

- added a changelog entry
- removed the temporary workaround to run the MR tests on Laravel 9
- added Laravel 9 to the unit test matrix
- bumped the bugsnag/bugsnag dependency to 3.27.0 (latest)