### PR TITLE
Run unstable tests against Laravel 9

### DIFF
--- a/.ci/patches/Dockerfile.patch
+++ b/.ci/patches/Dockerfile.patch
@@ -20,4 +20,4 @@ index 0000000..ecc7d44
 +
 +RUN php artisan key:generate
 +
-+CMD php -S 0.0.0.0:8000 server.php
++CMD php -S 0.0.0.0:8000 -t public/

--- a/.ci/patches/register-service-provider-and-facade.patch
+++ b/.ci/patches/register-service-provider-and-facade.patch
@@ -1,8 +1,8 @@
 diff --git a/config/app.php b/config/app.php
-index 8409e00..3592882 100644
+index 1941d7c..039b0d4 100644
 --- a/config/app.php
 +++ b/config/app.php
-@@ -165,6 +165,7 @@ return [
+@@ -167,6 +167,7 @@
          /*
           * Package Service Providers...
           */
@@ -10,12 +10,12 @@ index 8409e00..3592882 100644
  
          /*
           * Application Service Providers...
-@@ -227,6 +228,8 @@ return [
-         'Validator' => Illuminate\Support\Facades\Validator::class,
-         'View' => Illuminate\Support\Facades\View::class,
+@@ -191,7 +192,7 @@
+     */
  
+     'aliases' => Facade::defaultAliases()->merge([
+-        // ...
 +        'Bugsnag' => Bugsnag\BugsnagLaravel\Facades\Bugsnag::class,
-+
-     ],
+     ])->toArray(),
  
  ];

--- a/.github/workflows/unstable-version-tests.yml
+++ b/.github/workflows/unstable-version-tests.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [8.0]
-        laravel-version: ['8.x-dev as 8']
+        php-version: ['8.1']
+        laravel-version: ['9.x-dev', 'dev-master as 9']
 
     steps:
     - uses: actions/checkout@v2
@@ -37,9 +37,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [8.0]
+        php-version: ['8.1']
         laravel-fixture: [laravel-latest]
-        laravel-version: ['8.x-dev as 8'] #, 'dev-master as 8'] # disabled pending package updates in Laravel's skeleton app (PLAT-7040)
+        laravel-version: ['9.x-dev'] #, 'dev-master as 9'] # disabled pending package updates in Laravel's skeleton app (PLAT-7040)
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unstable-version-tests.yml
+++ b/.github/workflows/unstable-version-tests.yml
@@ -56,6 +56,12 @@ jobs:
         ruby-version: 2.7
         bundler-cache: true
 
+    - name: install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
+        coverage: none
+
     - run: ./.ci/setup-laravel-dev-fixture.sh ${{ matrix.laravel-version }}
 
     - run: PHP_VERSION=${{ matrix.php-version }} LARAVEL_FIXTURE=${{ matrix.laravel-fixture }} bundle exec bugsnag-maze-runner


### PR DESCRIPTION
## Goal

This PR swaps our nightly unstable tests to run against Laravel 9. This required a couple of changes due to differences in the default config and skeleton app setup

I've not reinstated the tests against the master branch as there's a dependency conflict that I don't get locally, so I'll need to spend some more time figuring out what's different

As these tests only run nightly they won't run on this PR, see https://github.com/bugsnag/bugsnag-laravel/runs/5123257935 for a successful run with these changes