### PR TITLE
Bugsnag::fake()

### DIFF
--- a/src/Facades/Bugsnag.php
+++ b/src/Facades/Bugsnag.php
@@ -2,6 +2,7 @@
 
 namespace Bugsnag\BugsnagLaravel\Facades;
 
+use Bugsnag\BugsnagLaravel\Testing\BugsnagFake;
 use Illuminate\Support\Facades\Facade;
 
 /**
@@ -61,6 +62,10 @@ use Illuminate\Support\Facades\Facade;
  * @method static bool shouldNotify()
  * @method static bool shouldSendCode()
  * @method static void startSession()
+ * @method static void assertNotified(string $reportName, callable|null $callback = null)
+ * @method static void assertNotifiedTimes(string $reportName, int $times = 1, callable|null $callback = null)
+ * @method static void assertNotNotified(string $reportName, callable|null $callback = null)
+ * @method static void assertNothingNotified()
  *
  * @see \Bugsnag\Client
  */
@@ -69,5 +74,17 @@ class Bugsnag extends Facade
     protected static function getFacadeAccessor()
     {
         return 'bugsnag';
+    }
+
+    /**
+     * Replace the bound instance with a fake.
+     *
+     * @return BugsnagFake
+     */
+    public static function fake()
+    {
+        static::swap($fake = BugsnagFake::fromClient(static::getFacadeRoot()));
+
+        return $fake;
     }
 }

--- a/src/Testing/BugsnagFake.php
+++ b/src/Testing/BugsnagFake.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Bugsnag\BugsnagLaravel\Testing;
+
+use Bugsnag\Client;
+use Bugsnag\Report;
+use GuzzleHttp\ClientInterface;
+use Illuminate\Support\Collection;
+use Mockery;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+class BugsnagFake extends Client
+{
+    /** @var HttpClientFake */
+    protected $http;
+
+    /**
+     * @param  Client  $client
+     * @return BugsnagFake
+     */
+    public static function fromClient(Client $client)
+    {
+        $instance = new self(
+            $client->getConfig(),
+            $client->resolver
+        );
+
+        // Use a Fake HttpClient that doesn't dispatch
+        // the Queue and that has a Queue getter.
+        $instance->http = new HttpClientFake(
+            $client->getConfig(),
+            Mockery::mock(ClientInterface::class)
+        );
+
+        return $instance;
+    }
+
+    /**
+     * Get all the reports matching a truth-test callback.
+     *
+     * @param  string  $name
+     * @param  callable(Report): bool|null  $callback
+     * @return Collection
+     */
+    public function notified($name, $callback = null)
+    {
+        $callback = $callback ?: function () {
+            return true;
+        };
+
+        return collect($this->http->getQueue())
+            ->filter(function (Report $report) use ($name) {
+                return $report->getName() === $name;
+            })
+            ->filter(function (Report $report) use ($callback) {
+                return $callback($report);
+            });
+    }
+
+
+    /**
+     * Assert if a report was notified based on a truth-test callback.
+     *
+     * @param  string  $reportName
+     * @param  callable(Report): bool|null  $callback
+     * @return void
+     */
+    public function assertNotified($reportName, $callback = null)
+    {
+        PHPUnit::assertTrue(
+            $this->notified($reportName, $callback)->isNotEmpty(),
+            "The expected [{$reportName}] report was not notified."
+        );
+    }
+
+    /**
+     * Assert if a report was pushed a number of times.
+     *
+     * @param  string  $reportName
+     * @param  int  $times
+     * @param  callable(Report): bool|int|null  $callback
+     * @return void
+     */
+    public function assertNotifiedTimes($reportName, $times = 1, $callback = null)
+    {
+        $count = $this->notified($reportName, $callback)->count();
+
+        PHPUnit::assertSame(
+            $times, $count,
+            "The expected [{$reportName}] bugsnag was reported {$count} times instead of {$times} times."
+        );
+    }
+
+    /**
+     * Determine if a report was notified based on a truth-test callback.
+     *
+     * @param  string  $reportName
+     * @param  callable(Report): bool|null  $callback
+     * @return void
+     */
+    public function assertNotNotified($reportName, $callback = null)
+    {
+        PHPUnit::assertTrue(
+            $this->notified($reportName, $callback)->count() === 0 &&
+            "The unexpected [{$reportName}] report was notified."
+        );
+    }
+
+    /**
+     * Assert that no bugsnag reports were notified.
+     *
+     * @return void
+     */
+    public function assertNothingNotified()
+    {
+        PHPUnit::assertEmpty($this->http->getQueue(), 'Bugsnags were notified unexpectedly.');
+    }
+}

--- a/src/Testing/BugsnagFake.php
+++ b/src/Testing/BugsnagFake.php
@@ -15,7 +15,8 @@ class BugsnagFake extends Client
     protected $http;
 
     /**
-     * @param  Client  $client
+     * @param Client $client
+     *
      * @return BugsnagFake
      */
     public static function fromClient(Client $client)
@@ -38,31 +39,32 @@ class BugsnagFake extends Client
     /**
      * Get all the reports matching a truth-test callback.
      *
-     * @param  string  $name
-     * @param  callable(Report): bool|null  $callback
+     * @param string                      $reportName
+     * @param callable(Report): bool|null $callback
+     *
      * @return Collection
      */
-    public function notified($name, $callback = null)
+    public function notified($reportName, $callback = null)
     {
         $callback = $callback ?: function () {
             return true;
         };
 
         return collect($this->http->getQueue())
-            ->filter(function (Report $report) use ($name) {
-                return $report->getName() === $name;
+            ->filter(function (Report $report) use ($reportName) {
+                return $report->getName() === $reportName;
             })
             ->filter(function (Report $report) use ($callback) {
                 return $callback($report);
             });
     }
 
-
     /**
      * Assert if a report was notified based on a truth-test callback.
      *
-     * @param  string  $reportName
-     * @param  callable(Report): bool|null  $callback
+     * @param string                      $reportName
+     * @param callable(Report): bool|null $callback
+     *
      * @return void
      */
     public function assertNotified($reportName, $callback = null)
@@ -76,9 +78,10 @@ class BugsnagFake extends Client
     /**
      * Assert if a report was pushed a number of times.
      *
-     * @param  string  $reportName
-     * @param  int  $times
-     * @param  callable(Report): bool|int|null  $callback
+     * @param string                          $reportName
+     * @param int                             $times
+     * @param callable(Report): bool|int|null $callback
+     *
      * @return void
      */
     public function assertNotifiedTimes($reportName, $times = 1, $callback = null)
@@ -86,7 +89,8 @@ class BugsnagFake extends Client
         $count = $this->notified($reportName, $callback)->count();
 
         PHPUnit::assertSame(
-            $times, $count,
+            $times,
+            $count,
             "The expected [{$reportName}] bugsnag was reported {$count} times instead of {$times} times."
         );
     }
@@ -94,8 +98,9 @@ class BugsnagFake extends Client
     /**
      * Determine if a report was notified based on a truth-test callback.
      *
-     * @param  string  $reportName
-     * @param  callable(Report): bool|null  $callback
+     * @param string                      $reportName
+     * @param callable(Report): bool|null $callback
+     *
      * @return void
      */
     public function assertNotNotified($reportName, $callback = null)

--- a/src/Testing/HttpClientFake.php
+++ b/src/Testing/HttpClientFake.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Bugsnag\BugsnagLaravel\Testing;
+
+use Bugsnag\HttpClient;
+use Bugsnag\Report;
+
+class HttpClientFake extends HttpClient
+{
+    public function sendEvents()
+    {
+        // Do nothing!
+    }
+
+    public function sendBuildReport(array $buildInfo)
+    {
+        // Do nothing!
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection<Report>|Report[]
+     */
+    public function getQueue()
+    {
+        return collect($this->queue);
+    }
+}

--- a/tests/FakeTest.php
+++ b/tests/FakeTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Bugsnag\BugsnagLaravel\Tests;
+
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
+use Bugsnag\Report;
+use PHPUnit\Framework\ExpectationFailedException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class FakeTest extends AbstractTestCase
+{
+    public function testFakeShouldInterceptNotifyErrorCorrectly()
+    {
+        Bugsnag::fake();
+
+        Bugsnag::notifyError('Hi!', 'This is an example error.');
+
+        $this->assertEquals(
+            1,
+            Bugsnag::notified('Hi!')->count(),
+            'Event was notified'
+        );
+    }
+
+    public function testFakeShouldInterceptNotifyExceptionCorrectly()
+    {
+        Bugsnag::fake();
+
+        Bugsnag::notifyException(new NotFoundHttpException('oops'));
+
+        $this->assertEquals(
+            1,
+            Bugsnag::notified(NotFoundHttpException::class, function (Report $report) {
+                return $report->getMessage() === 'oops';
+            })->count(),
+            'Event was notified'
+        );
+    }
+
+    public function testFakeShouldInterceptNotifyCorrectly()
+    {
+        Bugsnag::fake();
+
+        Bugsnag::notify(
+            Report::fromNamedError(Bugsnag::getConfig(), 'This is my name!', 'my message')
+        );
+
+        $this->assertEquals(
+            1,
+            Bugsnag::notified('This is my name!', function (Report $report) {
+                return $report->getMessage() === 'my message';
+            })->count(),
+            'Event should be notified'
+        );
+
+        $this->assertEquals(
+            0,
+            Bugsnag::notified('This is my name!', function (Report $report) {
+                return $report->getMessage() === 'Different message';
+            })->count(),
+            'Non-existent event should not be notified'
+        );
+    }
+
+    public function testShouldAssertNothingWasNotified()
+    {
+        Bugsnag::fake();
+
+        Bugsnag::assertNothingNotified();
+
+        Bugsnag::notifyError('Hi!', 'This is an example error.');
+
+        $this->expectException(ExpectationFailedException::class);
+
+        Bugsnag::assertNothingNotified();
+    }
+
+    public function testShouldAssertNotNotified()
+    {
+        Bugsnag::fake();
+
+        Bugsnag::assertNotNotified('Hi!');
+
+        Bugsnag::notifyError('Hi!', 'This is an example error.');
+
+        $this->expectException(ExpectationFailedException::class);
+
+        Bugsnag::assertNotNotified('Hi!');
+    }
+
+    public function testShouldAssertNotifiedTimes()
+    {
+        Bugsnag::fake();
+
+        Bugsnag::assertNotifiedTimes('Hi!', 0);
+
+        Bugsnag::notifyError('Hi!', 'Foo');
+        Bugsnag::notifyError('Hi!', 'Foo');
+
+        Bugsnag::assertNotifiedTimes('Hi!', 2);
+
+        Bugsnag::notifyError('Hi!', 'Bar');
+
+        Bugsnag::assertNotifiedTimes('Hi!', 3);
+
+        Bugsnag::assertNotifiedTimes('Hi!', 2, function (Report $report) {
+            return $report->getMessage() === 'Foo';
+        });
+        Bugsnag::assertNotifiedTimes('Hi!', 1, function (Report $report) {
+            return $report->getMessage() === 'Bar';
+        });
+
+        $this->expectException(ExpectationFailedException::class);
+
+        // Make sure it breaks when the times is not correct.
+
+        Bugsnag::assertNotifiedTimes('Hi!', 2, function (Report $report) {
+            return $report->getMessage() === 'Bar';
+        });
+    }
+
+    public function testShouldAssertNotified()
+    {
+        Bugsnag::fake();
+
+        Bugsnag::notifyError('Hi!', 'Foo');
+
+        Bugsnag::assertNotified('Hi!');
+
+        Bugsnag::notifyError('Hi!', 'Foo');
+
+        // Should work even when tracking twice.
+        Bugsnag::assertNotified('Hi!');
+
+        Bugsnag::notifyError('Hi!', 'Bar');
+
+        Bugsnag::assertNotified('Hi!', function (Report $report) {
+            return $report->getMessage() === 'Bar';
+        });
+
+        $this->expectException(ExpectationFailedException::class);
+
+        // Make sure it breaks when the times is not correct.
+
+        Bugsnag::assertNotified('Hi!', function (Report $report) {
+            return $report->getMessage() === 'Bar FALSE';
+        });
+    }
+}


### PR DESCRIPTION
## Goal

When testing a project, I find myself mocking the bugsnag Facade in order to assert that certain events are called.
Instead of a mock or a spy, many developers (me included) prefer to assert using a Fake. [Here is why I think so](https://juampi92.medium.com/mocking-spying-or-faking-your-facades-e2a95ab198d7).

This PR simply adds a way to simply fake Busgnag, and it contains some assertion helpers to facilitate testing.

## Design

The Fake approach is very similar to what Laravel is doing already with the [Fakes the framework provides](https://github.com/laravel/framework/tree/9.x/src/Illuminate/Support/Testing/Fakes).

To instanciate, the Facade now ships with a `fake` method that will do the swap (just like the [Bus Facade](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Support/Facades/Bus.php#L44)).
To assert that certain reports were notified, the Fake contains some assertion methods very similar to the ones Laravel ships with ([source code](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Support/Testing/Fakes/BusFake.php#L80) and (documentation)[https://laravel.com/docs/9.x/mocking#bus-fake])

### Why faking the HttpClient?

The only operation I want to avoid doing is posting to any Bugsnag endpoints. The Http client is the class in charge of flushing the queue and dispatching the reports, so I figured that I would simply:
- Replace all methods that perform a request to a bugsnag endpoint with dummy methods.
- Add a getter to expose the Queue so we can assert that certain reports were notified.

Perhaps the HttpClient could have been a partial mock, but I decided to create a class nonetheless.

## Changeset

The production API is left intact. The update only concerns the testing environment.

## Testing

I added a FakeTest that simulates normal tests and makes sure the assert methods are doing the proper checks.