### PR TITLE
Add support for loading feature flags & experiments in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+ ### Enhancements
+
+ * New APIs to support feature flag and experiment functionality. For more information, please see https://docs.bugsnag.com/product/features-experiments.
+   [#153](https://github.com/bugsnag/bugsnag-laravel/pull/487)
+
 ## 2.23.0 (2022-02-09)
 
 ### Enhancements

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "bugsnag/bugsnag": "^3.27.0",
+        "bugsnag/bugsnag": "^3.28.0",
         "bugsnag/bugsnag-psr-logger": "^1.4|^2.0",
         "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0",
         "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0",

--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -330,4 +330,23 @@ return [
     */
 
     'redacted_keys' => empty(env('BUGSNAG_REDACTED_KEYS')) ? null : explode(',', env('BUGSNAG_REDACTED_KEYS')),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Feature flags
+    |--------------------------------------------------------------------------
+    |
+    | An array of feature flags to add to all reports.
+    |
+    | Each element in the array must have a "name" key and can optionally have a
+    | "variant" key, for example:
+    |
+    | [
+    |     ['name' => 'example without a variant'],
+    |     ['name' => 'example with a variant', 'variant' => 'example of a variant'],
+    | ]
+    |
+    */
+
+    'feature_flags' => [],
 ];

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -9,6 +9,7 @@ use Bugsnag\BugsnagLaravel\Request\LaravelResolver;
 use Bugsnag\Callbacks\CustomUser;
 use Bugsnag\Client;
 use Bugsnag\Configuration;
+use Bugsnag\FeatureFlag;
 use Bugsnag\PsrLogger\BugsnagLogger;
 use Bugsnag\PsrLogger\MultiLogger as BaseMultiLogger;
 use Bugsnag\Report;
@@ -243,6 +244,24 @@ class BugsnagServiceProvider extends ServiceProvider
 
             if (isset($config['redacted_keys']) && is_array($config['redacted_keys'])) {
                 $client->setRedactedKeys($config['redacted_keys']);
+            }
+
+            if (isset($config['feature_flags']) && is_array($config['feature_flags']) && $config['feature_flags'] !== []) {
+                $featureFlags = [];
+
+                foreach ($config['feature_flags'] as $flag) {
+                    if (!is_array($flag) || !array_key_exists('name', $flag)) {
+                        continue;
+                    }
+
+                    if (array_key_exists('variant', $flag)) {
+                        $featureFlags[] = new FeatureFlag($flag['name'], $flag['variant']);
+                    } else {
+                        $featureFlags[] = new FeatureFlag($flag['name']);
+                    }
+                }
+
+                $client->addFeatureFlags($featureFlags);
             }
 
             return $client;


### PR DESCRIPTION
## Goal

This PR adds support for loading feature flags & experiments in the `bugsnag.php` config file, e.g.:

```php
'feature_flags' => [
    [
        'name' => 'Checkout button color',
        'variant' => 'Blue',
    ],
    [
        'name' => 'Special offer',
        'variant' => 'Free coffee',
    ],
    [
        'name' => 'New checkout flow',
    ],
],
```

This is useful when features are known upfront, but when that's not possible the feature flags API can be used to configure feature flags at runtime