### PR TITLE
Allow Monolog v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Added support for Monolog 3.0
+  [#489](https://github.com/bugsnag/bugsnag-laravel/pull/489)
+
 ## 2.24.0 (2022-05-20)
 
 ### Enhancements

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "bugsnag/bugsnag-psr-logger": "^1.4|^2.0",
         "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0",
         "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0",
-        "monolog/monolog": "^1.12|^2.0"
+        "monolog/monolog": "^1.12|^2.0|^3.0"
     },
     "require-dev": {
         "orchestra/testbench": "^3.1|^4.0|^5.0|^6.0|^7.0",


### PR DESCRIPTION
## Goal

Laravel v10 will require Monolog v3 (https://github.com/laravel/framework/pull/42311), so we'll also need to allow it so that we can be compatible when it eventually releases. This is required to allow testing against pre-release versions and to allow our nightly "unstable" builds to run again

We only use Monolog in one place and the APIs we use haven't changed in v3, so no other changes are required:

https://github.com/bugsnag/bugsnag-laravel/blob/1853d8335e2c29412abd14e3522fbca0a4351d84/src/BugsnagServiceProvider.php#L289-L293