### PR TITLE
Fix unstable test patch

### DIFF
--- a/.ci/patches/register-service-provider-and-facade.patch
+++ b/.ci/patches/register-service-provider-and-facade.patch
@@ -14,7 +14,7 @@ index 1941d7c..039b0d4 100644
      */
  
      'aliases' => Facade::defaultAliases()->merge([
--        // ...
+-        // 'ExampleClass' => App\Example\ExampleClass::class,
 +        'Bugsnag' => Bugsnag\BugsnagLaravel\Facades\Bugsnag::class,
      ])->toArray(),
  


### PR DESCRIPTION
## Goal

One of the patches we use to configure Bugsnag with unreleased Laravel versions doesn't apply as the comment has changed. This PR fixes the patch, which allows the unstable tests to run again — [see this successful build](https://github.com/bugsnag/bugsnag-laravel/runs/6527005997?check_suite_focus=true)