### PR TITLE
Fix CI failing due to changes to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,10 @@
         "test": "phpunit"
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "kylekatarnls/update-helper": false
+        }
+    }
 }

--- a/features/fixtures/laravel56/composer.json
+++ b/features/fixtures/laravel56/composer.json
@@ -62,6 +62,10 @@
         ]
     },
     "config": {
+        "allow-plugins": {
+            "kylekatarnls/update-helper": false,
+            "symfony/thanks": false
+        },
         "preferred-install": "dist",
         "sort-packages": true,
         "optimize-autoloader": true


### PR DESCRIPTION
## Goal

[Composer v2.2.16](https://github.com/composer/composer/releases/tag/2.2.16) changed the default behaviour to throw an error when an unknown plugin is run. This breaks CI as we currently don't configure any plugins, so whenever a Composer plugin runs it will throw an error

This happens on quite a few combinations of PHP/Laravel versions but not all — some versions of Laravel don't pull in any plugins so some builds were still passing. This affected a lot of the unit test matrix but only the Laravel 5.6 Maze Runner test fixture

These plugins aren't useful for us so I've disabled them:

- `kylekatarnls/update-helper` isn't useful as we intentionally install old versions of Laravel for compatibility testing
- `symfony/thanks` was pulled in by the Laravel 5.6 fixture, but this is almost never run manually so the output wouldn't be seen