### PR TITLE
[2.x] Uses `NullableShutdownStrategy` on tests

### DIFF
--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -195,7 +195,7 @@ class BugsnagServiceProvider extends ServiceProvider
 
             $shutdownStrategy = null;
 
-            if ($app instanceof LaravelApplication && $app->runningUnitTests()) {
+            if (class_exists(NullableShutdownStrategy::class) && $app instanceof LaravelApplication && $app->runningUnitTests()) {
                 $shutdownStrategy = new NullableShutdownStrategy();
             }
 


### PR DESCRIPTION
This pull request fixes a memory leak of this package with Laravel's unit tests, where the `Illuminate\Foundation\Application` instance is being leaked to PHP's internal shutdown function.

In other words, Laravel often creates application instances during tests, and bugsnag is registering (for each new test case) a new shutdown function with those application instances.

With this fix, we're able to decrease the memory usage of a 600 test suite by 14% percent:
```
Tests: 600
Before: 190.50 MB
After: 168.50 MB
```

Note, [#65](https://github.com/bugsnag/bugsnag-php/pull/65) equally needs to merged and tagged.