### PR TITLE
chore: cast message to string if not instanceof `Jsonable`, `Arrayable`

### DIFF
--- a/src/LaravelLogger.php
+++ b/src/LaravelLogger.php
@@ -86,6 +86,6 @@ class LaravelLogger extends BugsnagLogger implements Log
             return var_export($message->toArray(), true);
         }
 
-        return $message;
+        return (string) $message;
     }
 }


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->