### PR TITLE
Fix test to expect feature flags correctly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "bugsnag/bugsnag": "^3.28.0",
+        "bugsnag/bugsnag": "^3.29.0",
         "bugsnag/bugsnag-psr-logger": "^1.4|^2.0",
         "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0",
         "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0",

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -9,6 +9,7 @@ use Bugsnag\BugsnagLaravel\Queue\Tracker;
 use Bugsnag\BugsnagLaravel\Tests\Stubs\Injectee;
 use Bugsnag\BugsnagLaravel\Tests\Stubs\InjecteeWithLogInterface;
 use Bugsnag\Client;
+use Bugsnag\FeatureFlag;
 use Bugsnag\PsrLogger\BugsnagLogger;
 use Bugsnag\PsrLogger\MultiLogger as BaseMultiLogger;
 use Illuminate\Contracts\Logging\Log;
@@ -486,14 +487,14 @@ class ServiceProviderTest extends AbstractTestCase
         $this->assertInstanceOf(Client::class, $client);
 
         $expected = [
-            ['featureFlag' => 'flag1'],
-            ['featureFlag' => 'flag2', 'variant' => 'yes'],
-            ['featureFlag' => 'flag4'],
+            new FeatureFlag('flag1'),
+            new FeatureFlag('flag2', 'yes'),
+            new FeatureFlag('flag4'),
         ];
 
         $actual = $client->getConfig()->getFeatureFlagsCopy()->toArray();
 
-        $this->assertSame($expected, $actual);
+        $this->assertEquals($expected, $actual);
     }
 
     public function testFeatureFlagsAreNotSetWhenNotAnArray()


### PR DESCRIPTION
The private API for getting feature flags changed in v3.29.0