### PR TITLE
Add max_breadcrumbs config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Added support for Monolog 3.0
   [#489](https://github.com/bugsnag/bugsnag-laravel/pull/489)
 
+* Add `max_breadcrumbs` config option for configuring the maximum number of breadcrumbs to attach to a report
+  [#496](https://github.com/bugsnag/bugsnag-laravel/pull/496)
+
 ## 2.24.0 (2022-05-20)
 
 ### Enhancements

--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -349,4 +349,16 @@ return [
     */
 
     'feature_flags' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Max breadcrumbs
+    |--------------------------------------------------------------------------
+    |
+    | The maximum number of breadcrumbs to send with a report.
+    |
+    | This should be an integer between 0-100 (inclusive).
+    */
+
+    'max_breadcrumbs' => null,
 ];

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -264,6 +264,10 @@ class BugsnagServiceProvider extends ServiceProvider
                 $client->addFeatureFlags($featureFlags);
             }
 
+            if (isset($config['max_breadcrumbs'])) {
+                $client->setMaxBreadcrumbs($config['max_breadcrumbs']);
+            }
+
             return $client;
         });
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -515,4 +515,20 @@ class ServiceProviderTest extends AbstractTestCase
 
         $this->assertSame([], $actual);
     }
+
+    public function testMaxBreadcrumbsCanBeSetFromConfig()
+    {
+        /** @var \Illuminate\Config\Repository $laravelConfig */
+        $laravelConfig = $this->app->config;
+        $bugsnagConfig = $laravelConfig->get('bugsnag');
+        $bugsnagConfig['max_breadcrumbs'] = 73;
+
+        $laravelConfig->set('bugsnag', $bugsnagConfig);
+
+        /** @var Client $client */
+        $client = $this->app->make(Client::class);
+
+        $this->assertInstanceOf(Client::class, $client);
+        $this->assertSame(73, $client->getMaxBreadcrumbs());
+    }
 }


### PR DESCRIPTION
## Goal

Add `max_breadcrumbs` config option for configuring the maximum number of breadcrumbs to attach to a report: https://docs.bugsnag.com/platforms/php/other/configuration-options/#max-breadcrumbs