### PR TITLE
Release v2.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Added support for Monolog 3.0
   [#489](https://github.com/bugsnag/bugsnag-laravel/pull/489)
 
+* Add `max_breadcrumbs` config option for configuring the maximum number of breadcrumbs to attach to a report
+  [#496](https://github.com/bugsnag/bugsnag-laravel/pull/496)
+
 ## 2.24.0 (2022-05-20)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## TBD
+## 2.25.0 (2022-10-25)
 
 ### Enhancements
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "bugsnag/bugsnag": "^3.28.0",
+        "bugsnag/bugsnag": "^3.29.0",
         "bugsnag/bugsnag-psr-logger": "^1.4|^2.0",
         "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0",
         "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0",

--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -349,4 +349,16 @@ return [
     */
 
     'feature_flags' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Max breadcrumbs
+    |--------------------------------------------------------------------------
+    |
+    | The maximum number of breadcrumbs to send with a report.
+    |
+    | This should be an integer between 0-100 (inclusive).
+    */
+
+    'max_breadcrumbs' => null,
 ];

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -37,7 +37,7 @@ class BugsnagServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    const VERSION = '2.24.0';
+    const VERSION = '2.25.0';
 
     /**
      * Boot the service provider.

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -264,6 +264,10 @@ class BugsnagServiceProvider extends ServiceProvider
                 $client->addFeatureFlags($featureFlags);
             }
 
+            if (isset($config['max_breadcrumbs'])) {
+                $client->setMaxBreadcrumbs($config['max_breadcrumbs']);
+            }
+
             return $client;
         });
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -9,6 +9,7 @@ use Bugsnag\BugsnagLaravel\Queue\Tracker;
 use Bugsnag\BugsnagLaravel\Tests\Stubs\Injectee;
 use Bugsnag\BugsnagLaravel\Tests\Stubs\InjecteeWithLogInterface;
 use Bugsnag\Client;
+use Bugsnag\FeatureFlag;
 use Bugsnag\PsrLogger\BugsnagLogger;
 use Bugsnag\PsrLogger\MultiLogger as BaseMultiLogger;
 use Illuminate\Contracts\Logging\Log;
@@ -486,14 +487,14 @@ class ServiceProviderTest extends AbstractTestCase
         $this->assertInstanceOf(Client::class, $client);
 
         $expected = [
-            ['featureFlag' => 'flag1'],
-            ['featureFlag' => 'flag2', 'variant' => 'yes'],
-            ['featureFlag' => 'flag4'],
+            new FeatureFlag('flag1'),
+            new FeatureFlag('flag2', 'yes'),
+            new FeatureFlag('flag4'),
         ];
 
         $actual = $client->getConfig()->getFeatureFlagsCopy()->toArray();
 
-        $this->assertSame($expected, $actual);
+        $this->assertEquals($expected, $actual);
     }
 
     public function testFeatureFlagsAreNotSetWhenNotAnArray()

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -515,4 +515,20 @@ class ServiceProviderTest extends AbstractTestCase
 
         $this->assertSame([], $actual);
     }
+
+    public function testMaxBreadcrumbsCanBeSetFromConfig()
+    {
+        /** @var \Illuminate\Config\Repository $laravelConfig */
+        $laravelConfig = $this->app->config;
+        $bugsnagConfig = $laravelConfig->get('bugsnag');
+        $bugsnagConfig['max_breadcrumbs'] = 73;
+
+        $laravelConfig->set('bugsnag', $bugsnagConfig);
+
+        /** @var Client $client */
+        $client = $this->app->make(Client::class);
+
+        $this->assertInstanceOf(Client::class, $client);
+        $this->assertSame(73, $client->getMaxBreadcrumbs());
+    }
 }


### PR DESCRIPTION
### Enhancements

* Added support for Monolog 3.0
  [#489](https://github.com/bugsnag/bugsnag-laravel/pull/489)

* Add `max_breadcrumbs` config option for configuring the maximum number of breadcrumbs to attach to a report
  [#496](https://github.com/bugsnag/bugsnag-laravel/pull/496)
