### PR TITLE
Fix events from CLI commands always being marked handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix events from CLI commands always being handled when using the `NunoMaduro\Collision` package
+  [#503](https://github.com/bugsnag/bugsnag-laravel/pull/503)
+
 ## 2.25.0 (2022-10-25)
 
 ### Enhancements

--- a/tests/Middleware/UnhandledStateTest.php
+++ b/tests/Middleware/UnhandledStateTest.php
@@ -159,6 +159,34 @@ class UnhandledStateTest extends TestCase
             ['function' => 'z'],
             ['class' => \Yet\AnotherClass::class],
         ]];
+
+        yield 'backtrace with NunoMaduro\\Collision Adapter' => [[
+            [
+                'file' => '/app/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php',
+                'function' => 'error',
+                'class' => 'Illuminate\\Log\\LogManager',
+            ],
+            [
+                'file' => '/app/app/Exceptions/Handler.php',
+                'function' => 'report',
+                'class' => 'Illuminate\\Foundation\\Exceptions\\Handler',
+            ],
+            [
+                'file' => '/app/vendor/nunomaduro/collision/src/Adapters/Laravel/ExceptionHandler.php',
+                'function' => 'report',
+                'class' => 'App\\Exceptions\\Handler',
+            ],
+            [
+                'file' => '/app/vendor/laravel/framework/src/Illuminate/Queue/Worker.php',
+                'function' => 'report',
+                'class' => 'NunoMaduro\\Collision\\Adapters\\Laravel\\ExceptionHandler',
+            ],
+            [
+                'file' => '/app/vendor/laravel/framework/src/Illuminate/Queue/Worker.php',
+                'function' => 'runJob',
+                'class' => 'Illuminate\\Queue\\Worker',
+            ],
+        ]];
     }
 
     public function unhandledBacktraceProviderLumen()


### PR DESCRIPTION
## Goal

When a CLI command is run, NunoMaduro\Collision will end up in the backtrace where we expected to find a built-in Laravel or Lumen class (assuming Collision is installed)

This meant the `UnhandledState` middleware was not correctly marking these events as 'unhandled'

The BacktraceProcessor now supports `NunoMaduro\Collision` as a vendor namespace and so can mark these events as unhandled correctly