### PR TITLE
Add tests that run the queue worker once

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.6.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.9.0'

--- a/features/lib/laravel.rb
+++ b/features/lib/laravel.rb
@@ -53,11 +53,21 @@ class Laravel
       true
     end
 
-    def queue_worker_command(tries:)
+    # the command to run the queue worker for a single job
+    def queue_worker_once_command(tries)
+      if version < "5.3.0"
+        "php artisan queue:work --tries=#{tries}"
+      else
+        "php artisan queue:work --once --tries=#{tries}"
+      end
+    end
+
+    # the command to run the queue worker as a daemon
+    def queue_worker_daemon_command(tries)
       # the command to run the queue worker was 'queue:listen' but changed to
       # 'queue:work' in Laravel 5.3 ('queue:work' exists on older Laravels, but
       # is not quite equivalent)
-      if version < '5.3.0'
+      if version < "5.3.0"
         "php artisan queue:listen --tries=#{tries}"
       else
         "php artisan queue:work --tries=#{tries}"

--- a/features/queues.feature
+++ b/features/queues.feature
@@ -102,3 +102,113 @@ Scenario: Handled exceptions are delivered from queues when running the queue wo
   And the event "severity" equals "warning"
   And the event "unhandled" is false
   And the event "severityReason.type" equals "handledException"
+
+@not-laravel-latest @not-lumen8
+Scenario: Unhandled exceptions are delivered from queues when running the queue worker once
+  Given I start the laravel fixture
+  When I navigate to the route "/queue/unhandled"
+  Then I should receive no errors
+  When I run the laravel queue worker
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
+  And the exception "errorClass" equals "RuntimeException"
+  And the exception "message" equals "uh oh :o"
+  And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
+  And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
+  And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 1
+  And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
+  And on Laravel versions >= 5.2 the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
+  And on Laravel versions >= 5.2 the event "app.type" equals "Queue"
+  And on Laravel versions >= 5.2 the event "context" equals "App\Jobs\UnhandledJob"
+  And on Laravel versions < 5.2 the event "metaData.job" is null
+  And the event "severity" equals "error"
+  And the event "unhandled" is true
+  And the event "severityReason.type" equals "unhandledExceptionMiddleware"
+  And the event "severityReason.attributes.framework" equals "Laravel"
+
+@not-laravel-latest @not-lumen8
+Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker as a daemon
+  Given I start the laravel fixture
+  When I navigate to the route "/queue/unhandled"
+  Then I should receive no errors
+
+  # attempt 1
+  When I run the laravel queue worker with --tries=3
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
+  And the exception "errorClass" equals "RuntimeException"
+  And the exception "message" equals "uh oh :o"
+  And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
+  And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
+  And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 1
+  And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
+  And on Laravel versions >= 5.2 the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
+  And on Laravel versions >= 5.2 the event "app.type" equals "Queue"
+  And on Laravel versions >= 5.2 the event "context" equals "App\Jobs\UnhandledJob"
+  And on Laravel versions < 5.2 the event "metaData.job" is null
+  And the event "severity" equals "error"
+  And the event "unhandled" is true
+  And the event "severityReason.type" equals "unhandledExceptionMiddleware"
+  And the event "severityReason.attributes.framework" equals "Laravel"
+
+  # attempt 2
+  When I discard the oldest error
+  And I run the laravel queue worker with --tries=3
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
+  And the exception "errorClass" equals "RuntimeException"
+  And the exception "message" equals "uh oh :o"
+  And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
+  And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
+  And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 2
+  And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
+  And on Laravel versions >= 5.2 the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
+  And on Laravel versions >= 5.2 the event "app.type" equals "Queue"
+  And on Laravel versions >= 5.2 the event "context" equals "App\Jobs\UnhandledJob"
+  And on Laravel versions < 5.2 the event "metaData.job" is null
+  And the event "severity" equals "error"
+  And the event "unhandled" is true
+  And the event "severityReason.type" equals "unhandledExceptionMiddleware"
+  And the event "severityReason.attributes.framework" equals "Laravel"
+
+  # attempt 3
+  When I discard the oldest error
+  And I run the laravel queue worker with --tries=3
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
+  And the exception "errorClass" equals "RuntimeException"
+  And the exception "message" equals "uh oh :o"
+  And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
+  And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
+  And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 3
+  And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
+  And on Laravel versions >= 5.2 the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
+  And on Laravel versions >= 5.2 the event "app.type" equals "Queue"
+  And on Laravel versions >= 5.2 the event "context" equals "App\Jobs\UnhandledJob"
+  And on Laravel versions < 5.2 the event "metaData.job" is null
+  And the event "severity" equals "error"
+  And the event "unhandled" is true
+  And the event "severityReason.type" equals "unhandledExceptionMiddleware"
+  And the event "severityReason.attributes.framework" equals "Laravel"
+
+@not-laravel-latest @not-lumen8
+Scenario: Handled exceptions are delivered from queues when running the queue worker once
+  Given I start the laravel fixture
+  When I navigate to the route "/queue/handled"
+  Then I should receive no errors
+  When I run the laravel queue worker
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
+  And the exception "errorClass" equals "Exception"
+  And the exception "message" equals "Handled :)"
+  And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
+  And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
+  And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 1
+  And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
+  And on Laravel versions >= 5.2 the event "metaData.job.resolved" equals "App\Jobs\HandledJob"
+  And on Laravel versions >= 5.2 the event "app.type" equals "Queue"
+  And on Laravel versions >= 5.2 the event "context" equals "App\Jobs\HandledJob"
+  And on Laravel versions < 5.2 the event "metaData.job" is null
+  And the event "severity" equals "warning"
+  And the event "unhandled" is false
+  And the event "severityReason.type" equals "handledException"

--- a/features/queues.feature
+++ b/features/queues.feature
@@ -1,7 +1,7 @@
 Feature: Queue support
 
 @not-laravel-latest @not-lumen8
-Scenario: Unhandled exceptions are delivered from queues
+Scenario: Unhandled exceptions are delivered from queues when running the queue worker as a daemon
   Given I start the laravel fixture
   And I start the laravel queue worker
   When I navigate to the route "/queue/unhandled"
@@ -23,7 +23,7 @@ Scenario: Unhandled exceptions are delivered from queues
   And the event "severityReason.attributes.framework" equals "Laravel"
 
 @not-laravel-latest @not-lumen8
-Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts
+Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker as a daemon
   Given I start the laravel fixture
   And I start the laravel queue worker with --tries=3
   When I navigate to the route "/queue/unhandled"
@@ -83,7 +83,7 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "severityReason.attributes.framework" equals "Laravel"
 
 @not-laravel-latest @not-lumen8
-Scenario: Handled exceptions are delivered from queues
+Scenario: Handled exceptions are delivered from queues when running the queue worker as a daemon
   Given I start the laravel fixture
   And I start the laravel queue worker
   When I navigate to the route "/queue/handled"

--- a/features/steps/laravel_steps.rb
+++ b/features/steps/laravel_steps.rb
@@ -14,36 +14,22 @@ When(/^I start the laravel fixture$/) do
   }
 end
 
-# TODO: contribute this back to Maze Runner
-#       https://github.com/bugsnag/maze-runner/pull/425
 module Maze
   class Docker
     class << self
+      # TODO: remove when https://github.com/bugsnag/maze-runner/pull/425 is merged
       def exec(service, command, detach: false)
         flags = detach ? "--detach" : ""
 
         run_docker_compose_command("exec #{flags} #{service} #{command}")
       end
 
+      # TODO: contribute this back to Maze Runner
+      #       probably need a nicer API, capable of doing a copy in either
+      #       direction (right now this can only copy from the service to the
+      #       local machine)
       def cp(service, source:, destination:)
-        # cp only exists in 'docker compose' not 'docker-compose', i.e. only
-        # with a space and not a hyphen
-        # TODO: can we run all docker compose commands with a space?
-        run_docker_space_compose_command("cp #{service}:#{source} #{destination}")
-      end
-
-      private
-
-      def get_docker_space_compose_command(command)
-        project_name = compose_project_name.nil? ? '' : "-p #{compose_project_name}"
-
-        "docker compose #{project_name} -f #{COMPOSE_FILENAME} #{command}"
-      end
-
-      def run_docker_space_compose_command(command, success_codes: nil)
-        command = get_docker_space_compose_command(command)
-
-        @last_command_logs, @last_exit_code = Runner.run_command(command, success_codes: success_codes)
+        run_docker_compose_command("cp #{service}:#{source} #{destination}")
       end
     end
   end

--- a/features/steps/laravel_steps.rb
+++ b/features/steps/laravel_steps.rb
@@ -40,7 +40,15 @@ When("I start the laravel queue worker") do
 end
 
 When("I start the laravel queue worker with --tries={int}") do |tries|
-  Maze::Docker.exec(Laravel.fixture, Laravel.queue_worker_command(tries: tries), detach: true)
+  Maze::Docker.exec(Laravel.fixture, Laravel.queue_worker_daemon_command(tries), detach: true)
+end
+
+When("I run the laravel queue worker") do
+  step("I run the laravel queue worker with --tries=1")
+end
+
+When("I run the laravel queue worker with --tries={int}") do |tries|
+  Maze::Docker.exec(Laravel.fixture, Laravel.queue_worker_once_command(tries))
 end
 
 When("I navigate to the route {string}") do |route|


### PR DESCRIPTION
## Goal

This PR adds tests that use the queue worker to process a single job, instead of using it as a daemon process

This is an important difference because the "looping" event doesn't fire when the queue worker isn't a daemon and we rely on "looping" for flushing events & cleanup between jobs:

https://github.com/bugsnag/bugsnag-laravel/blob/1dd9fb6a658f59f784657869d0d8028c583a59f0/src/BugsnagServiceProvider.php#L157-L161