### PR TITLE
Add assertions on breadcrumbs to queue tests

### DIFF
--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - BUGSNAG_REGISTER_OOM_BOOTSTRAPPER
       - BUGSNAG_DISCARD_CLASSES
       - BUGSNAG_REDACTED_KEYS
+      - BUGSNAG_QUERY
     restart: "no"
     ports:
       - target: 8000

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       - BUGSNAG_REGISTER_OOM_BOOTSTRAPPER
       - BUGSNAG_DISCARD_CLASSES
       - BUGSNAG_REDACTED_KEYS
+      - BUGSNAG_QUERY
     restart: "no"
     ports:
       - target: 8000

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -91,6 +91,7 @@ services:
       - BUGSNAG_REGISTER_OOM_BOOTSTRAPPER
       - BUGSNAG_DISCARD_CLASSES
       - BUGSNAG_REDACTED_KEYS
+      - BUGSNAG_QUERY
     restart: "no"
     ports:
       - target: 8000

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -110,6 +110,7 @@ services:
       - BUGSNAG_REGISTER_OOM_BOOTSTRAPPER
       - BUGSNAG_DISCARD_CLASSES
       - BUGSNAG_REDACTED_KEYS
+      - BUGSNAG_QUERY
     restart: "no"
     ports:
       - target: 8000

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - BUGSNAG_REGISTER_OOM_BOOTSTRAPPER
       - BUGSNAG_DISCARD_CLASSES
       - BUGSNAG_REDACTED_KEYS
+      - BUGSNAG_QUERY
     restart: "no"
     ports:
       - target: 8000

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       - BUGSNAG_REGISTER_OOM_BOOTSTRAPPER
       - BUGSNAG_DISCARD_CLASSES
       - BUGSNAG_REDACTED_KEYS
+      - BUGSNAG_QUERY
     restart: "no"
     ports:
       - target: 8000

--- a/features/fixtures/laravel51/app/Jobs/HandledJob.php
+++ b/features/fixtures/laravel51/app/Jobs/HandledJob.php
@@ -17,6 +17,8 @@ class HandledJob extends Job implements SelfHandling, ShouldQueue
      */
     public function handle()
     {
+        Bugsnag::leaveBreadcrumb(__METHOD__);
+
         Bugsnag::notifyException(new Exception('Handled :)'));
     }
 }

--- a/features/fixtures/laravel51/app/Jobs/UnhandledJob.php
+++ b/features/fixtures/laravel51/app/Jobs/UnhandledJob.php
@@ -6,6 +6,7 @@ use App\Jobs\Job;
 use RuntimeException;
 use Illuminate\Contracts\Bus\SelfHandling;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
 
 class UnhandledJob extends Job implements SelfHandling, ShouldQueue
 {
@@ -16,6 +17,8 @@ class UnhandledJob extends Job implements SelfHandling, ShouldQueue
      */
     public function handle()
     {
+        Bugsnag::leaveBreadcrumb(__METHOD__);
+
         throw new RuntimeException('uh oh :o');
     }
 }

--- a/features/fixtures/laravel51/app/Providers/AppServiceProvider.php
+++ b/features/fixtures/laravel51/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -13,7 +14,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Bugsnag::leaveBreadcrumb(__METHOD__);
     }
 
     /**

--- a/features/fixtures/laravel51/app/Providers/EventServiceProvider.php
+++ b/features/fixtures/laravel51/app/Providers/EventServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Queue;
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -28,6 +30,8 @@ class EventServiceProvider extends ServiceProvider
     {
         parent::boot($events);
 
-        //
+        Queue::after(function () {
+            Bugsnag::leaveBreadcrumb('after');
+        });
     }
 }

--- a/features/fixtures/laravel56/app/Jobs/HandledJob.php
+++ b/features/fixtures/laravel56/app/Jobs/HandledJob.php
@@ -21,6 +21,8 @@ class HandledJob implements ShouldQueue
      */
     public function handle()
     {
+        Bugsnag::leaveBreadcrumb(__METHOD__);
+
         Bugsnag::notifyException(new Exception('Handled :)'));
     }
 }

--- a/features/fixtures/laravel56/app/Jobs/UnhandledJob.php
+++ b/features/fixtures/laravel56/app/Jobs/UnhandledJob.php
@@ -8,6 +8,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
 
 class UnhandledJob implements ShouldQueue
 {
@@ -20,6 +21,8 @@ class UnhandledJob implements ShouldQueue
      */
     public function handle()
     {
+        Bugsnag::leaveBreadcrumb(__METHOD__);
+
         throw new RuntimeException('uh oh :o');
     }
 }

--- a/features/fixtures/laravel56/app/Providers/AppServiceProvider.php
+++ b/features/fixtures/laravel56/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -13,7 +14,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Bugsnag::leaveBreadcrumb(__METHOD__);
     }
 
     /**

--- a/features/fixtures/laravel56/app/Providers/EventServiceProvider.php
+++ b/features/fixtures/laravel56/app/Providers/EventServiceProvider.php
@@ -4,6 +4,11 @@ namespace App\Providers;
 
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobExceptionOccurred;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -27,6 +32,16 @@ class EventServiceProvider extends ServiceProvider
     {
         parent::boot();
 
-        //
+        Queue::before(function (JobProcessing $event) {
+            Bugsnag::leaveBreadcrumb('before');
+        });
+
+        Queue::after(function (JobProcessed $event) {
+            Bugsnag::leaveBreadcrumb('after');
+        });
+
+        Queue::exceptionOccurred(function (JobExceptionOccurred $event) {
+            Bugsnag::leaveBreadcrumb('exceptionOccurred');
+        });
     }
 }

--- a/features/fixtures/laravel58/app/Jobs/HandledJob.php
+++ b/features/fixtures/laravel58/app/Jobs/HandledJob.php
@@ -21,6 +21,8 @@ class HandledJob implements ShouldQueue
      */
     public function handle()
     {
+        Bugsnag::leaveBreadcrumb(__METHOD__);
+
         Bugsnag::notifyException(new Exception('Handled :)'));
     }
 }

--- a/features/fixtures/laravel58/app/Jobs/UnhandledJob.php
+++ b/features/fixtures/laravel58/app/Jobs/UnhandledJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
 use RuntimeException;
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\SerializesModels;
@@ -20,6 +21,8 @@ class UnhandledJob implements ShouldQueue
      */
     public function handle()
     {
+        Bugsnag::leaveBreadcrumb(__METHOD__);
+
         throw new RuntimeException('uh oh :o');
     }
 }

--- a/features/fixtures/laravel58/app/Providers/AppServiceProvider.php
+++ b/features/fixtures/laravel58/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -34,6 +35,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Bugsnag::leaveBreadcrumb(__METHOD__);
     }
 }

--- a/features/fixtures/laravel58/app/Providers/EventServiceProvider.php
+++ b/features/fixtures/laravel58/app/Providers/EventServiceProvider.php
@@ -6,6 +6,11 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Queue;
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobExceptionOccurred;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -27,8 +32,16 @@ class EventServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        parent::boot();
+        Queue::before(function (JobProcessing $event) {
+            Bugsnag::leaveBreadcrumb('before');
+        });
 
-        //
+        Queue::after(function (JobProcessed $event) {
+            Bugsnag::leaveBreadcrumb('after');
+        });
+
+        Queue::exceptionOccurred(function (JobExceptionOccurred $event) {
+            Bugsnag::leaveBreadcrumb('exceptionOccurred');
+        });
     }
 }

--- a/features/fixtures/laravel66/app/Jobs/HandledJob.php
+++ b/features/fixtures/laravel66/app/Jobs/HandledJob.php
@@ -21,6 +21,8 @@ class HandledJob implements ShouldQueue
      */
     public function handle()
     {
+        Bugsnag::leaveBreadcrumb(__METHOD__);
+
         Bugsnag::notifyException(new Exception('Handled :)'));
     }
 }

--- a/features/fixtures/laravel66/app/Jobs/UnhandledJob.php
+++ b/features/fixtures/laravel66/app/Jobs/UnhandledJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -20,6 +21,8 @@ class UnhandledJob implements ShouldQueue
      */
     public function handle()
     {
+        Bugsnag::leaveBreadcrumb(__METHOD__);
+
         throw new RuntimeException('uh oh :o');
     }
 }

--- a/features/fixtures/laravel66/app/Providers/AppServiceProvider.php
+++ b/features/fixtures/laravel66/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -34,6 +35,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Bugsnag::leaveBreadcrumb(__METHOD__);
     }
 }

--- a/features/fixtures/laravel66/app/Providers/EventServiceProvider.php
+++ b/features/fixtures/laravel66/app/Providers/EventServiceProvider.php
@@ -6,6 +6,11 @@ use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobExceptionOccurred;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -27,8 +32,16 @@ class EventServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        parent::boot();
+        Queue::before(function (JobProcessing $event) {
+            Bugsnag::leaveBreadcrumb('before');
+        });
 
-        //
+        Queue::after(function (JobProcessed $event) {
+            Bugsnag::leaveBreadcrumb('after');
+        });
+
+        Queue::exceptionOccurred(function (JobExceptionOccurred $event) {
+            Bugsnag::leaveBreadcrumb('exceptionOccurred');
+        });
     }
 }

--- a/features/fixtures/laravel8/app/Jobs/HandledJob.php
+++ b/features/fixtures/laravel8/app/Jobs/HandledJob.php
@@ -22,6 +22,8 @@ class HandledJob implements ShouldQueue
      */
     public function handle()
     {
+        Bugsnag::leaveBreadcrumb(__METHOD__);
+
         Bugsnag::notifyException(new Exception('Handled :)'));
     }
 }

--- a/features/fixtures/laravel8/app/Jobs/UnhandledJob.php
+++ b/features/fixtures/laravel8/app/Jobs/UnhandledJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -21,6 +22,8 @@ class UnhandledJob implements ShouldQueue
      */
     public function handle()
     {
+        Bugsnag::leaveBreadcrumb(__METHOD__);
+
         throw new RuntimeException('uh oh :o');
     }
 }

--- a/features/fixtures/laravel8/app/Providers/AppServiceProvider.php
+++ b/features/fixtures/laravel8/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -34,6 +35,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Bugsnag::leaveBreadcrumb(__METHOD__);
     }
 }

--- a/features/fixtures/laravel8/app/Providers/EventServiceProvider.php
+++ b/features/fixtures/laravel8/app/Providers/EventServiceProvider.php
@@ -6,6 +6,11 @@ use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobExceptionOccurred;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -27,6 +32,16 @@ class EventServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Queue::before(function (JobProcessing $event) {
+            Bugsnag::leaveBreadcrumb('before');
+        });
+
+        Queue::after(function (JobProcessed $event) {
+            Bugsnag::leaveBreadcrumb('after');
+        });
+
+        Queue::exceptionOccurred(function (JobExceptionOccurred $event) {
+            Bugsnag::leaveBreadcrumb('exceptionOccurred');
+        });
     }
 }

--- a/features/fixtures/laravel9/app/Jobs/HandledJob.php
+++ b/features/fixtures/laravel9/app/Jobs/HandledJob.php
@@ -22,6 +22,8 @@ class HandledJob implements ShouldQueue
      */
     public function handle()
     {
+        Bugsnag::leaveBreadcrumb(__METHOD__);
+
         Bugsnag::notifyException(new Exception('Handled :)'));
     }
 }

--- a/features/fixtures/laravel9/app/Jobs/UnhandledJob.php
+++ b/features/fixtures/laravel9/app/Jobs/UnhandledJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -21,6 +22,8 @@ class UnhandledJob implements ShouldQueue
      */
     public function handle()
     {
+        Bugsnag::leaveBreadcrumb(__METHOD__);
+
         throw new RuntimeException('uh oh :o');
     }
 }

--- a/features/fixtures/laravel9/app/Providers/AppServiceProvider.php
+++ b/features/fixtures/laravel9/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -34,6 +35,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Bugsnag::leaveBreadcrumb(__METHOD__);
     }
 }

--- a/features/fixtures/laravel9/app/Providers/EventServiceProvider.php
+++ b/features/fixtures/laravel9/app/Providers/EventServiceProvider.php
@@ -6,6 +6,11 @@ use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobExceptionOccurred;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -27,6 +32,16 @@ class EventServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Queue::before(function (JobProcessing $event) {
+            Bugsnag::leaveBreadcrumb('before');
+        });
+
+        Queue::after(function (JobProcessed $event) {
+            Bugsnag::leaveBreadcrumb('after');
+        });
+
+        Queue::exceptionOccurred(function (JobExceptionOccurred $event) {
+            Bugsnag::leaveBreadcrumb('exceptionOccurred');
+        });
     }
 }

--- a/features/queues.feature
+++ b/features/queues.feature
@@ -127,7 +127,7 @@ Scenario: Unhandled exceptions are delivered from queues when running the queue 
   And the event "severityReason.attributes.framework" equals "Laravel"
 
 @not-laravel-latest @not-lumen8
-Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker as a daemon
+Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker once
   Given I start the laravel fixture
   When I navigate to the route "/queue/unhandled"
   Then I should receive no errors

--- a/features/queues.feature
+++ b/features/queues.feature
@@ -26,10 +26,10 @@ Scenario: Unhandled exceptions are delivered from queues when running the queue 
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.8 the event has 3 breadcrumbs
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.2 the event has 3 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker as a daemon
@@ -54,10 +54,10 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.8 the event has 3 breadcrumbs
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.2 the event has 3 breadcrumbs
 
   # attempt 2
   When I discard the oldest error
@@ -76,10 +76,10 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.8 the event has 3 breadcrumbs
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.2 the event has 3 breadcrumbs
 
   # attempt 3
   When I discard the oldest error
@@ -98,10 +98,10 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.8 the event has 3 breadcrumbs
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.2 the event has 3 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Handled exceptions are delivered from queues when running the queue worker as a daemon
@@ -123,9 +123,9 @@ Scenario: Handled exceptions are delivered from queues when running the queue wo
   And the event "severity" equals "warning"
   And the event "unhandled" is false
   And the event "severityReason.type" equals "handledException"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
-  And on Laravel versions >= 5.8 the event has 2 breadcrumbs
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
+  And on Laravel versions >= 5.2 the event has 2 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queues when running the queue worker once
@@ -149,11 +149,11 @@ Scenario: Unhandled exceptions are delivered from queues when running the queue 
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.8 the event has 4 breadcrumbs
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.2 the event has 4 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker once
@@ -179,11 +179,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.8 the event has 4 breadcrumbs
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.2 the event has 4 breadcrumbs
 
   # attempt 2
   When I discard the oldest error
@@ -204,11 +204,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.8 the event has 4 breadcrumbs
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.2 the event has 4 breadcrumbs
 
   # attempt 3
   When I discard the oldest error
@@ -229,11 +229,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.8 the event has 4 breadcrumbs
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.2 the event has 4 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Handled exceptions are delivered from queues when running the queue worker once
@@ -256,7 +256,7 @@ Scenario: Handled exceptions are delivered from queues when running the queue wo
   And the event "severity" equals "warning"
   And the event "unhandled" is false
   And the event "severityReason.type" equals "handledException"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
-  And on Laravel versions >= 5.8 the event has 3 breadcrumbs
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
+  And on Laravel versions >= 5.2 the event has 3 breadcrumbs

--- a/features/queues.feature
+++ b/features/queues.feature
@@ -26,10 +26,10 @@ Scenario: Unhandled exceptions are delivered from queues when running the queue 
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 8.0 the event has 3 breadcrumbs
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 6.0 the event has 3 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker as a daemon
@@ -54,10 +54,10 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 8.0 the event has 3 breadcrumbs
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 6.0 the event has 3 breadcrumbs
 
   # attempt 2
   When I discard the oldest error
@@ -76,10 +76,10 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 8.0 the event has 3 breadcrumbs
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 6.0 the event has 3 breadcrumbs
 
   # attempt 3
   When I discard the oldest error
@@ -98,10 +98,10 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 8.0 the event has 3 breadcrumbs
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 6.0 the event has 3 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Handled exceptions are delivered from queues when running the queue worker as a daemon
@@ -123,9 +123,9 @@ Scenario: Handled exceptions are delivered from queues when running the queue wo
   And the event "severity" equals "warning"
   And the event "unhandled" is false
   And the event "severityReason.type" equals "handledException"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
-  And on Laravel versions >= 8.0 the event has 2 breadcrumbs
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
+  And on Laravel versions >= 6.0 the event has 2 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queues when running the queue worker once
@@ -149,11 +149,11 @@ Scenario: Unhandled exceptions are delivered from queues when running the queue 
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 8.0 the event has 4 breadcrumbs
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 6.0 the event has 4 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker once
@@ -179,11 +179,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 8.0 the event has 4 breadcrumbs
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 6.0 the event has 4 breadcrumbs
 
   # attempt 2
   When I discard the oldest error
@@ -204,11 +204,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 8.0 the event has 4 breadcrumbs
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 6.0 the event has 4 breadcrumbs
 
   # attempt 3
   When I discard the oldest error
@@ -229,11 +229,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 8.0 the event has 4 breadcrumbs
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 6.0 the event has 4 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Handled exceptions are delivered from queues when running the queue worker once
@@ -256,7 +256,7 @@ Scenario: Handled exceptions are delivered from queues when running the queue wo
   And the event "severity" equals "warning"
   And the event "unhandled" is false
   And the event "severityReason.type" equals "handledException"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
-  And on Laravel versions >= 8.0 the event has 3 breadcrumbs
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
+  And on Laravel versions >= 6.0 the event has 3 breadcrumbs

--- a/features/queues.feature
+++ b/features/queues.feature
@@ -1,5 +1,10 @@
 Feature: Queue support
 
+Background:
+  # disable automatic query breadcrumbs as we assert against the specific number
+  # of breadcrumbs in these tests
+  Given I set environment variable "BUGSNAG_QUERY" to "false"
+
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queues when running the queue worker as a daemon
   Given I start the laravel fixture
@@ -21,6 +26,10 @@ Scenario: Unhandled exceptions are delivered from queues when running the queue 
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 9.0 the event has 3 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker as a daemon
@@ -45,6 +54,10 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 9.0 the event has 3 breadcrumbs
 
   # attempt 2
   When I discard the oldest error
@@ -63,6 +76,10 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 9.0 the event has 3 breadcrumbs
 
   # attempt 3
   When I discard the oldest error
@@ -81,6 +98,10 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 9.0 the event has 3 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Handled exceptions are delivered from queues when running the queue worker as a daemon
@@ -102,6 +123,9 @@ Scenario: Handled exceptions are delivered from queues when running the queue wo
   And the event "severity" equals "warning"
   And the event "unhandled" is false
   And the event "severityReason.type" equals "handledException"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
+  And on Laravel versions >= 9.0 the event has 2 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queues when running the queue worker once
@@ -125,6 +149,11 @@ Scenario: Unhandled exceptions are delivered from queues when running the queue 
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 9.0 the event has 4 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker once
@@ -150,6 +179,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 9.0 the event has 4 breadcrumbs
 
   # attempt 2
   When I discard the oldest error
@@ -170,6 +204,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 9.0 the event has 4 breadcrumbs
 
   # attempt 3
   When I discard the oldest error
@@ -190,6 +229,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 9.0 the event has 4 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Handled exceptions are delivered from queues when running the queue worker once
@@ -212,3 +256,7 @@ Scenario: Handled exceptions are delivered from queues when running the queue wo
   And the event "severity" equals "warning"
   And the event "unhandled" is false
   And the event "severityReason.type" equals "handledException"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
+  And on Laravel versions >= 9.0 the event has 3 breadcrumbs

--- a/features/queues.feature
+++ b/features/queues.feature
@@ -14,24 +14,30 @@ Scenario: Unhandled exceptions are delivered from queues when running the queue 
   Then the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "RuntimeException"
   And the exception "message" equals "uh oh :o"
-  And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
-  And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
-  And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 1
-  And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
-  And on Laravel versions >= 5.2 the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions >= 5.2 the event "app.type" equals "Queue"
-  And on Laravel versions >= 5.2 the event "context" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions < 5.2 the event "metaData.job" is null
   And the event "severity" equals "error"
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
   And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.2 the event has 3 breadcrumbs
-  And on Laravel versions < 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions < 5.2 the event has 2 breadcrumbs
+  And on Laravel versions >= 5.2:
+    """
+    the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
+    the event "metaData.job.queue" equals "default"
+    the event "metaData.job.attempts" equals 1
+    the event "metaData.job.connection" equals "database"
+    the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
+    the event "app.type" equals "Queue"
+    the event "context" equals "App\Jobs\UnhandledJob"
+    the event has a "manual" breadcrumb named "before"
+    the event has a "manual" breadcrumb named "exceptionOccurred"
+    the event has 3 breadcrumbs
+    """
+  And on Laravel versions < 5.2:
+    """
+    the event "metaData.job" is null
+    the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+    the event has 2 breadcrumbs
+    """
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker as a daemon
@@ -44,72 +50,90 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   Then the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "RuntimeException"
   And the exception "message" equals "uh oh :o"
-  And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
-  And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
-  And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 1
-  And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
-  And on Laravel versions >= 5.2 the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions >= 5.2 the event "app.type" equals "Queue"
-  And on Laravel versions >= 5.2 the event "context" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions < 5.2 the event "metaData.job" is null
   And the event "severity" equals "error"
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
   And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.2 the event has 3 breadcrumbs
-  And on Laravel versions < 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions < 5.2 the event has 2 breadcrumbs
+  And on Laravel versions >= 5.2:
+    """
+    the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
+    the event "metaData.job.queue" equals "default"
+    the event "metaData.job.attempts" equals 1
+    the event "metaData.job.connection" equals "database"
+    the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
+    the event "app.type" equals "Queue"
+    the event "context" equals "App\Jobs\UnhandledJob"
+    the event has a "manual" breadcrumb named "before"
+    the event has a "manual" breadcrumb named "exceptionOccurred"
+    the event has 3 breadcrumbs
+    """
+  And on Laravel versions < 5.2:
+    """
+    the event "metaData.job" is null
+    the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+    the event has 2 breadcrumbs
+    """
 
   # attempt 2
   When I discard the oldest error
   Then the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "RuntimeException"
   And the exception "message" equals "uh oh :o"
-  And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
-  And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
-  And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 2
-  And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
-  And on Laravel versions >= 5.2 the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions >= 5.2 the event "app.type" equals "Queue"
-  And on Laravel versions >= 5.2 the event "context" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions < 5.2 the event "metaData.job" is null
   And the event "severity" equals "error"
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
   And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.2 the event has 3 breadcrumbs
-  And on Laravel versions < 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions < 5.2 the event has 2 breadcrumbs
+  And on Laravel versions >= 5.2:
+    """
+    the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
+    the event "metaData.job.queue" equals "default"
+    the event "metaData.job.attempts" equals 2
+    the event "metaData.job.connection" equals "database"
+    the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
+    the event "app.type" equals "Queue"
+    the event "context" equals "App\Jobs\UnhandledJob"
+    the event has a "manual" breadcrumb named "before"
+    the event has a "manual" breadcrumb named "exceptionOccurred"
+    the event has 3 breadcrumbs
+    """
+  And on Laravel versions < 5.2:
+    """
+    the event "metaData.job" is null
+    the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+    the event has 2 breadcrumbs
+    """
 
   # attempt 3
   When I discard the oldest error
   Then the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "RuntimeException"
   And the exception "message" equals "uh oh :o"
-  And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
-  And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
-  And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 3
-  And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
-  And on Laravel versions >= 5.2 the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions >= 5.2 the event "app.type" equals "Queue"
-  And on Laravel versions >= 5.2 the event "context" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions < 5.2 the event "metaData.job" is null
   And the event "severity" equals "error"
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
   And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.2 the event has 3 breadcrumbs
-  And on Laravel versions < 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions < 5.2 the event has 2 breadcrumbs
+  And on Laravel versions >= 5.2:
+    """
+    the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
+    the event "metaData.job.queue" equals "default"
+    the event "metaData.job.attempts" equals 3
+    the event "metaData.job.connection" equals "database"
+    the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
+    the event "app.type" equals "Queue"
+    the event "context" equals "App\Jobs\UnhandledJob"
+    the event has a "manual" breadcrumb named "before"
+    the event has a "manual" breadcrumb named "exceptionOccurred"
+    the event has 3 breadcrumbs
+    """
+  And on Laravel versions < 5.2:
+    """
+    the event "metaData.job" is null
+    the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+    the event has 2 breadcrumbs
+    """
 
 @not-laravel-latest @not-lumen8
 Scenario: Handled exceptions are delivered from queues when running the queue worker as a daemon
@@ -120,21 +144,27 @@ Scenario: Handled exceptions are delivered from queues when running the queue wo
   Then the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "Exception"
   And the exception "message" equals "Handled :)"
-  And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
-  And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
-  And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 1
-  And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
-  And on Laravel versions >= 5.2 the event "metaData.job.resolved" equals "App\Jobs\HandledJob"
-  And on Laravel versions >= 5.2 the event "app.type" equals "Queue"
-  And on Laravel versions >= 5.2 the event "context" equals "App\Jobs\HandledJob"
-  And on Laravel versions < 5.2 the event "metaData.job" is null
   And the event "severity" equals "warning"
   And the event "unhandled" is false
   And the event "severityReason.type" equals "handledException"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
   And the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
-  And on Laravel versions < 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
   And the event has 2 breadcrumbs
+  And on Laravel versions >= 5.2:
+    """
+    the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
+    the event "metaData.job.queue" equals "default"
+    the event "metaData.job.attempts" equals 1
+    the event "metaData.job.connection" equals "database"
+    the event "metaData.job.resolved" equals "App\Jobs\HandledJob"
+    the event "app.type" equals "Queue"
+    the event "context" equals "App\Jobs\HandledJob"
+    the event has a "manual" breadcrumb named "before"
+    """
+  And on Laravel versions < 5.2:
+    """
+    the event "metaData.job" is null
+    the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+    """
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queues when running the queue worker once
@@ -146,24 +176,30 @@ Scenario: Unhandled exceptions are delivered from queues when running the queue 
   Then the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "RuntimeException"
   And the exception "message" equals "uh oh :o"
-  And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
-  And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
-  And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 1
-  And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
-  And on Laravel versions >= 5.2 the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions >= 5.2 the event "app.type" equals "Queue"
-  And on Laravel versions >= 5.2 the event "context" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions < 5.2 the event "metaData.job" is null
   And the event "severity" equals "error"
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
   And the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
   And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.2 the event has 4 breadcrumbs
-  And on Laravel versions < 5.2 the event has 2 breadcrumbs
+  And on Laravel versions >= 5.2:
+    """
+    the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
+    the event "metaData.job.queue" equals "default"
+    the event "metaData.job.attempts" equals 1
+    the event "metaData.job.connection" equals "database"
+    the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
+    the event "app.type" equals "Queue"
+    the event "context" equals "App\Jobs\UnhandledJob"
+    the event has a "manual" breadcrumb named "before"
+    the event has a "manual" breadcrumb named "exceptionOccurred"
+    the event has 4 breadcrumbs
+    """
+  And on Laravel versions < 5.2:
+    """
+    the event "metaData.job" is null
+    the event has 2 breadcrumbs
+    """
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker once
@@ -177,24 +213,30 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   Then the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "RuntimeException"
   And the exception "message" equals "uh oh :o"
-  And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
-  And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
-  And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 1
-  And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
-  And on Laravel versions >= 5.2 the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions >= 5.2 the event "app.type" equals "Queue"
-  And on Laravel versions >= 5.2 the event "context" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions < 5.2 the event "metaData.job" is null
   And the event "severity" equals "error"
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
   And the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
   And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.2 the event has 4 breadcrumbs
-  And on Laravel versions < 5.2 the event has 2 breadcrumbs
+  And on Laravel versions >= 5.2:
+    """
+    the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
+    the event "metaData.job.queue" equals "default"
+    the event "metaData.job.attempts" equals 1
+    the event "metaData.job.connection" equals "database"
+    the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
+    the event "app.type" equals "Queue"
+    the event "context" equals "App\Jobs\UnhandledJob"
+    the event has a "manual" breadcrumb named "before"
+    the event has a "manual" breadcrumb named "exceptionOccurred"
+    the event has 4 breadcrumbs
+    """
+  And on Laravel versions < 5.2:
+    """
+    the event "metaData.job" is null
+    the event has 2 breadcrumbs
+    """
 
   # attempt 2
   When I discard the oldest error
@@ -203,24 +245,30 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   Then the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "RuntimeException"
   And the exception "message" equals "uh oh :o"
-  And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
-  And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
-  And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 2
-  And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
-  And on Laravel versions >= 5.2 the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions >= 5.2 the event "app.type" equals "Queue"
-  And on Laravel versions >= 5.2 the event "context" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions < 5.2 the event "metaData.job" is null
   And the event "severity" equals "error"
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
   And the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
   And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.2 the event has 4 breadcrumbs
-  And on Laravel versions < 5.2 the event has 2 breadcrumbs
+  And on Laravel versions >= 5.2:
+    """
+    the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
+    the event "metaData.job.queue" equals "default"
+    the event "metaData.job.attempts" equals 2
+    the event "metaData.job.connection" equals "database"
+    the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
+    the event "app.type" equals "Queue"
+    the event "context" equals "App\Jobs\UnhandledJob"
+    the event has a "manual" breadcrumb named "before"
+    the event has a "manual" breadcrumb named "exceptionOccurred"
+    the event has 4 breadcrumbs
+    """
+  And on Laravel versions < 5.2:
+    """
+    the event "metaData.job" is null
+    the event has 2 breadcrumbs
+    """
 
   # attempt 3
   When I discard the oldest error
@@ -229,24 +277,30 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   Then the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "RuntimeException"
   And the exception "message" equals "uh oh :o"
-  And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
-  And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
-  And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 3
-  And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
-  And on Laravel versions >= 5.2 the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions >= 5.2 the event "app.type" equals "Queue"
-  And on Laravel versions >= 5.2 the event "context" equals "App\Jobs\UnhandledJob"
-  And on Laravel versions < 5.2 the event "metaData.job" is null
   And the event "severity" equals "error"
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
   And the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
   And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 5.2 the event has 4 breadcrumbs
-  And on Laravel versions < 5.2 the event has 2 breadcrumbs
+  And on Laravel versions >= 5.2:
+    """
+    the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
+    the event "metaData.job.queue" equals "default"
+    the event "metaData.job.attempts" equals 3
+    the event "metaData.job.connection" equals "database"
+    the event "metaData.job.resolved" equals "App\Jobs\UnhandledJob"
+    the event "app.type" equals "Queue"
+    the event "context" equals "App\Jobs\UnhandledJob"
+    the event has a "manual" breadcrumb named "before"
+    the event has a "manual" breadcrumb named "exceptionOccurred"
+    the event has 4 breadcrumbs
+    """
+  And on Laravel versions < 5.2:
+    """
+    the event "metaData.job" is null
+    the event has 2 breadcrumbs
+    """
 
 @not-laravel-latest @not-lumen8
 Scenario: Handled exceptions are delivered from queues when running the queue worker once
@@ -258,19 +312,25 @@ Scenario: Handled exceptions are delivered from queues when running the queue wo
   Then the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
   And the exception "errorClass" equals "Exception"
   And the exception "message" equals "Handled :)"
-  And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
-  And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
-  And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 1
-  And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
-  And on Laravel versions >= 5.2 the event "metaData.job.resolved" equals "App\Jobs\HandledJob"
-  And on Laravel versions >= 5.2 the event "app.type" equals "Queue"
-  And on Laravel versions >= 5.2 the event "context" equals "App\Jobs\HandledJob"
-  And on Laravel versions < 5.2 the event "metaData.job" is null
   And the event "severity" equals "warning"
   And the event "unhandled" is false
   And the event "severityReason.type" equals "handledException"
   And the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
   And the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
-  And on Laravel versions >= 5.2 the event has 3 breadcrumbs
-  And on Laravel versions < 5.2 the event has 2 breadcrumbs
+  And on Laravel versions >= 5.2:
+    """
+    the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
+    the event "metaData.job.queue" equals "default"
+    the event "metaData.job.attempts" equals 1
+    the event "metaData.job.connection" equals "database"
+    the event "metaData.job.resolved" equals "App\Jobs\HandledJob"
+    the event "app.type" equals "Queue"
+    the event "context" equals "App\Jobs\HandledJob"
+    the event has a "manual" breadcrumb named "before"
+    the event has 3 breadcrumbs
+    """
+  And on Laravel versions < 5.2:
+    """
+    the event "metaData.job" is null
+    the event has 2 breadcrumbs
+    """

--- a/features/queues.feature
+++ b/features/queues.feature
@@ -26,10 +26,12 @@ Scenario: Unhandled exceptions are delivered from queues when running the queue 
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
+  And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
   And on Laravel versions >= 5.2 the event has 3 breadcrumbs
+  And on Laravel versions < 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions < 5.2 the event has 2 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker as a daemon
@@ -55,9 +57,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
   And on Laravel versions >= 5.2 the event has 3 breadcrumbs
+  And on Laravel versions < 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions < 5.2 the event has 2 breadcrumbs
 
   # attempt 2
   When I discard the oldest error
@@ -77,9 +81,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
   And on Laravel versions >= 5.2 the event has 3 breadcrumbs
+  And on Laravel versions < 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions < 5.2 the event has 2 breadcrumbs
 
   # attempt 3
   When I discard the oldest error
@@ -99,9 +105,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
   And on Laravel versions >= 5.2 the event has 3 breadcrumbs
+  And on Laravel versions < 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions < 5.2 the event has 2 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Handled exceptions are delivered from queues when running the queue worker as a daemon
@@ -124,8 +132,9 @@ Scenario: Handled exceptions are delivered from queues when running the queue wo
   And the event "unhandled" is false
   And the event "severityReason.type" equals "handledException"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
-  And on Laravel versions >= 5.2 the event has 2 breadcrumbs
+  And the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
+  And on Laravel versions < 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And the event has 2 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queues when running the queue worker once
@@ -149,11 +158,12 @@ Scenario: Unhandled exceptions are delivered from queues when running the queue 
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
   And on Laravel versions >= 5.2 the event has 4 breadcrumbs
+  And on Laravel versions < 5.2 the event has 2 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker once
@@ -179,11 +189,12 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
   And on Laravel versions >= 5.2 the event has 4 breadcrumbs
+  And on Laravel versions < 5.2 the event has 2 breadcrumbs
 
   # attempt 2
   When I discard the oldest error
@@ -204,11 +215,12 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
   And on Laravel versions >= 5.2 the event has 4 breadcrumbs
+  And on Laravel versions < 5.2 the event has 2 breadcrumbs
 
   # attempt 3
   When I discard the oldest error
@@ -229,11 +241,12 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "exceptionOccurred"
   And on Laravel versions >= 5.2 the event has 4 breadcrumbs
+  And on Laravel versions < 5.2 the event has 2 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Handled exceptions are delivered from queues when running the queue worker once
@@ -256,7 +269,8 @@ Scenario: Handled exceptions are delivered from queues when running the queue wo
   And the event "severity" equals "warning"
   And the event "unhandled" is false
   And the event "severityReason.type" equals "handledException"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
   And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 5.2 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
+  And the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
   And on Laravel versions >= 5.2 the event has 3 breadcrumbs
+  And on Laravel versions < 5.2 the event has 2 breadcrumbs

--- a/features/queues.feature
+++ b/features/queues.feature
@@ -26,10 +26,10 @@ Scenario: Unhandled exceptions are delivered from queues when running the queue 
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 9.0 the event has 3 breadcrumbs
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 8.0 the event has 3 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker as a daemon
@@ -54,10 +54,10 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 9.0 the event has 3 breadcrumbs
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 8.0 the event has 3 breadcrumbs
 
   # attempt 2
   When I discard the oldest error
@@ -76,10 +76,10 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 9.0 the event has 3 breadcrumbs
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 8.0 the event has 3 breadcrumbs
 
   # attempt 3
   When I discard the oldest error
@@ -98,10 +98,10 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 9.0 the event has 3 breadcrumbs
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 8.0 the event has 3 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Handled exceptions are delivered from queues when running the queue worker as a daemon
@@ -123,9 +123,9 @@ Scenario: Handled exceptions are delivered from queues when running the queue wo
   And the event "severity" equals "warning"
   And the event "unhandled" is false
   And the event "severityReason.type" equals "handledException"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
-  And on Laravel versions >= 9.0 the event has 2 breadcrumbs
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
+  And on Laravel versions >= 8.0 the event has 2 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queues when running the queue worker once
@@ -149,11 +149,11 @@ Scenario: Unhandled exceptions are delivered from queues when running the queue 
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 9.0 the event has 4 breadcrumbs
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 8.0 the event has 4 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker once
@@ -179,11 +179,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 9.0 the event has 4 breadcrumbs
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 8.0 the event has 4 breadcrumbs
 
   # attempt 2
   When I discard the oldest error
@@ -204,11 +204,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 9.0 the event has 4 breadcrumbs
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 8.0 the event has 4 breadcrumbs
 
   # attempt 3
   When I discard the oldest error
@@ -229,11 +229,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 9.0 the event has 4 breadcrumbs
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 8.0 the event has 4 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Handled exceptions are delivered from queues when running the queue worker once
@@ -256,7 +256,7 @@ Scenario: Handled exceptions are delivered from queues when running the queue wo
   And the event "severity" equals "warning"
   And the event "unhandled" is false
   And the event "severityReason.type" equals "handledException"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 9.0 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
-  And on Laravel versions >= 9.0 the event has 3 breadcrumbs
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 8.0 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
+  And on Laravel versions >= 8.0 the event has 3 breadcrumbs

--- a/features/queues.feature
+++ b/features/queues.feature
@@ -26,10 +26,10 @@ Scenario: Unhandled exceptions are delivered from queues when running the queue 
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 6.0 the event has 3 breadcrumbs
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.8 the event has 3 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker as a daemon
@@ -54,10 +54,10 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 6.0 the event has 3 breadcrumbs
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.8 the event has 3 breadcrumbs
 
   # attempt 2
   When I discard the oldest error
@@ -76,10 +76,10 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 6.0 the event has 3 breadcrumbs
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.8 the event has 3 breadcrumbs
 
   # attempt 3
   When I discard the oldest error
@@ -98,10 +98,10 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 6.0 the event has 3 breadcrumbs
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.8 the event has 3 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Handled exceptions are delivered from queues when running the queue worker as a daemon
@@ -123,9 +123,9 @@ Scenario: Handled exceptions are delivered from queues when running the queue wo
   And the event "severity" equals "warning"
   And the event "unhandled" is false
   And the event "severityReason.type" equals "handledException"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
-  And on Laravel versions >= 6.0 the event has 2 breadcrumbs
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
+  And on Laravel versions >= 5.8 the event has 2 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queues when running the queue worker once
@@ -149,11 +149,11 @@ Scenario: Unhandled exceptions are delivered from queues when running the queue 
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 6.0 the event has 4 breadcrumbs
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.8 the event has 4 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Unhandled exceptions are delivered from queued jobs with multiple attmpts when running the queue worker once
@@ -179,11 +179,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 6.0 the event has 4 breadcrumbs
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.8 the event has 4 breadcrumbs
 
   # attempt 2
   When I discard the oldest error
@@ -204,11 +204,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 6.0 the event has 4 breadcrumbs
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.8 the event has 4 breadcrumbs
 
   # attempt 3
   When I discard the oldest error
@@ -229,11 +229,11 @@ Scenario: Unhandled exceptions are delivered from queued jobs with multiple attm
   And the event "unhandled" is true
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Laravel"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "exceptionOccurred"
-  And on Laravel versions >= 6.0 the event has 4 breadcrumbs
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\UnhandledJob::handle"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "exceptionOccurred"
+  And on Laravel versions >= 5.8 the event has 4 breadcrumbs
 
 @not-laravel-latest @not-lumen8
 Scenario: Handled exceptions are delivered from queues when running the queue worker once
@@ -256,7 +256,7 @@ Scenario: Handled exceptions are delivered from queues when running the queue wo
   And the event "severity" equals "warning"
   And the event "unhandled" is false
   And the event "severityReason.type" equals "handledException"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "before"
-  And on Laravel versions >= 6.0 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
-  And on Laravel versions >= 6.0 the event has 3 breadcrumbs
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Providers\AppServiceProvider::boot"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "before"
+  And on Laravel versions >= 5.8 the event has a "manual" breadcrumb named "App\Jobs\HandledJob::handle"
+  And on Laravel versions >= 5.8 the event has 3 breadcrumbs

--- a/features/steps/laravel_steps.rb
+++ b/features/steps/laravel_steps.rb
@@ -119,6 +119,26 @@ Then("the session payload field {string} matches the current major Lumen version
   step("the session payload field '#{path}' matches the regex '^((\\d+\\.){2}\\d+|\\d\\.x-dev)$'")
 end
 
+# TODO: remove when https://github.com/bugsnag/maze-runner/pull/433 is released
+Then("the event has {int} breadcrumb(s)") do |expected|
+  breadcrumbs = Maze::Server.errors.current[:body]['events'].first['breadcrumbs']
+
+  Maze.check.equal(
+    expected,
+    breadcrumbs.length,
+    "Expected event to have '#{expected}' breadcrumbs, but got: #{breadcrumbs}"
+  )
+end
+
+Then("the event has no breadcrumbs") do
+  breadcrumbs = Maze::Server.errors.current[:body]['events'].first['breadcrumbs']
+
+  Maze.check.true(
+    breadcrumbs.nil? || breadcrumbs.empty?,
+    "Expected event not to have breadcrumbs, but got: #{breadcrumbs}"
+  )
+end
+
 # conditionally run a step if the laravel version matches a specified version
 #
 # e.g. this will only check app.type on Laravel 5.2 and above:


### PR DESCRIPTION
## Goal

This PR adds assertions to the number of breadcrumbs left in the queue tests. This is important because we rely on the "looping" event to clear breadcrumbs between jobs:

https://github.com/bugsnag/bugsnag-laravel/blob/1dd9fb6a658f59f784657869d0d8028c583a59f0/src/BugsnagServiceProvider.php#L157-L161

In order to make this work consistently across Laravel versions, I've disabled the default query breadcrumbs and left breadcrumbs at various lifecycle points:

- when the AppServiceProvider boots
- before a job
- after a job (only fires for successful jobs)
- when an exception occurs in a job (not supported on Laravel 5.1)
- inside both `HandledJob` and `UnhandledJob`

Laravel 5.1 doesn't support all of these events, so has different breadcrumbs than the rest of the fixtures

I've also refactored the feature file to simplify the steps where there's a difference between Laravel versions. Instead of:

```gherkin
And on Laravel versions >= 5.2 the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
And on Laravel versions >= 5.2 the event "metaData.job.queue" equals "default"
And on Laravel versions >= 5.2 the event "metaData.job.attempts" equals 1
And on Laravel versions >= 5.2 the event "metaData.job.connection" equals "database"
```

You can now do this:

```gherkin
And on Laravel versions >= 5.2:
  """
  the event "metaData.job.name" equals "Illuminate\Queue\CallQueuedHandler@call"
  the event "metaData.job.queue" equals "default"
  the event "metaData.job.attempts" equals 1
  the event "metaData.job.connection" equals 
  """
```