### PR TITLE
Ensure events are sent from queues when using Laravel Vapor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,18 @@ Changelog
 
 ## TBD
 
+### Enhancements
+
+* Ensure events are sent from queues when using Laravel Vapor
+  [#511](https://github.com/bugsnag/bugsnag-laravel/pull/511)
+
 ### Bug fixes
 
 * Fix events from CLI commands always being handled when using the `NunoMaduro\Collision` package
   [#503](https://github.com/bugsnag/bugsnag-laravel/pull/503)
+
+* Fix breadcrumbs leaking between queued jobs when using Laravel Vapor
+  [#511](https://github.com/bugsnag/bugsnag-laravel/pull/511)
 
 ## 2.25.0 (2022-10-25)
 

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -211,6 +211,9 @@ class BugsnagServiceProvider extends ServiceProvider
         static $batchSendingWasDisabledByUs = false;
 
         $queue->before(function () use (&$batchSendingWasDisabledByUs) {
+            // clear breadcrumbs to stop them leaking between jobs
+            $this->app->bugsnag->clearBreadcrumbs();
+
             // only re-enable batch sending if we're the ones disabling it
             // this allows users to disable batch sending entirely
             if ($batchSendingWasDisabledByUs) {

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -180,6 +180,68 @@ class BugsnagServiceProvider extends ServiceProvider
 
             $this->app->make(Tracker::class)->set($job);
         });
+
+        $this->setupQueueForLaravelVapor($queue);
+    }
+
+    /**
+     * Setup queue events for Laravel Vapor.
+     *
+     * This is required because Laravel Vapor's queue system doesn't behave as
+     * a daemonised queue worker (the 'looping' event never fires) but also
+     * doesn't behave as a non-daemonised queue worker (our shutdown function
+     * never fires).
+     *
+     * @param QueueManager $queue
+     *
+     * @return void
+     */
+    private function setupQueueForLaravelVapor(QueueManager $queue)
+    {
+        // ensure we're running on vapor
+        // this is how vapor-core does it, e.g.:
+        // https://github.com/laravel/vapor-core/blob/61437221090850ba6e51dce15d0058d362654f9b/src/ConfiguresAssets.php#L16-L19
+        if (!isset($_ENV['VAPOR_SSM_PATH'])) {
+            return;
+        }
+
+        // used to keep track of if we're the ones disabling batch sending, so we
+        // know if we need to re-enable it - if the user disables batch sending
+        // then they don't want it enabled at all
+        static $batchSendingWasDisabledByUs = false;
+
+        $queue->before(function () use (&$batchSendingWasDisabledByUs) {
+            // only re-enable batch sending if we're the ones disabling it
+            // this allows users to disable batch sending entirely
+            if ($batchSendingWasDisabledByUs) {
+                $this->app->bugsnag->setBatchSending(true);
+            }
+        });
+
+        $flush = function () use (&$batchSendingWasDisabledByUs) {
+            // flush any events created in this job
+            $this->app->bugsnag->flush();
+
+            // disable batch sending so any events after this get sent synchronously
+            // this is important as exceptions are logged after the 'exceptionOccurred'
+            // event fires, so the above flush is too early to send them
+            // these exceptions would get sent after processing the next queued job,
+            // but we'd still drop the last event when this queue worker stops running
+            if ($this->app->bugsnag->isBatchSending()) {
+                $this->app->bugsnag->setBatchSending(false);
+                $batchSendingWasDisabledByUs = true;
+            }
+        };
+
+        // added in 5.2.41
+        if (method_exists($queue, 'after')) {
+            $queue->after($flush);
+        }
+
+        // added in 5.2.41
+        if (method_exists($queue, 'exceptionOccurred')) {
+            $queue->exceptionOccurred($flush);
+        }
     }
 
     /**


### PR DESCRIPTION
## Goal

Currently we never flush events in queued jobs when using Laravel Vapor because it does not call our shutdown function or fire the 'looping' event

To fix this, we need to:

1. flush events in 'after' and 'exceptionOccurred' in order to send any events created during the execution of a job
2. disable batch sending in 'after' and 'exceptionOccurred' so that any events created when a job finishes get sent synchronously. Otherwise we'd fail to send these events if the queue worker doesn't run another job
3. Re-enable batch sending in 'before' if we previously disabled it. This allows users to get the performance benefits of batch sending while their job is running (though it's much less relevant in a queue process)

This ensures that events created in a job are sent (when we call `flush`) and events created after a job are sent (as they are sent synchronously)

This PR also fixes breadcrumbs leaking between jobs; they are now cleared in the 'before' event on Laravel Vapor

## Testing

Unfortunately this can't really be tested (short of running Vapor on CI) because these changes are specific to the way queues workers behave on Vapor. Any unit test would only prove the code is run as written, not that this actually works when run on Vapor