### PR TITLE
Bump to PHP 8.2 in unstable version tests

### DIFF
--- a/.github/workflows/unstable-version-tests.yml
+++ b/.github/workflows/unstable-version-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1']
+        php-version: ['8.2']
         laravel-version: ['9.x-dev', 'dev-master as 9']
 
     steps:
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1']
+        php-version: ['8.2']
         laravel-fixture: [laravel-latest]
         laravel-version: ['9.x-dev'] #, 'dev-master as 9'] # disabled pending package updates in Laravel's skeleton app (PLAT-7040)
 


### PR DESCRIPTION
## Goal

Laravel recently changed their minimum PHP version requirement in the master branch to 8.2, but we're using 8.1 on CI so these tests aren't running

Bumping to 8.2 fixes this: https://github.com/bugsnag/bugsnag-laravel/actions/runs/3929504792

Targeting master as these scheduled tests can only run against master