### PR TITLE
Set minimum stability to 'dev' when setting up test fixture

### DIFF
--- a/.ci/setup-laravel-dev-fixture.sh
+++ b/.ci/setup-laravel-dev-fixture.sh
@@ -27,6 +27,7 @@ cd laravel-latest
 
 composer require laravel/framework:"$LARAVEL_VERSION" --update-with-dependencies --no-update
 composer config repositories.bugsnag-laravel '{ "type": "path", "url": "../../../", "options": { "symlink": false } }'
+composer config minimum-stability dev
 composer require bugsnag/bugsnag-laravel '*' --no-update
 
 composer update --no-dev


### PR DESCRIPTION
## Goal

Composer refuses to install bugsnag-laravel from the path repository as the [Laravel skeleton app's minimum stability was recently changed to 'stable'](https://github.com/laravel/laravel/commit/c1092ec084bb294a61b0f1c2149fddd662f1fc55). Setting it to 'dev' instead fixes this and allows installation to continue

## Testing

Failing test run (before this PR): https://github.com/bugsnag/bugsnag-laravel/actions/runs/3982247402/jobs/6826542863#step:6:304
Passing test run (after this PR): https://github.com/bugsnag/bugsnag-laravel/actions/runs/3985414951/jobs/6832765336