### PR TITLE
Add support for Laravel 10

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -106,6 +106,10 @@ jobs:
             laravel-version: '9.*'
           - php-version: '8.2'
             laravel-version: '9.*'
+          - php-version: '8.1'
+            laravel-version: '10.*'
+          - php-version: '8.2'
+            laravel-version: '10.*'
 
     steps:
     - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "php": ">=5.5",
         "bugsnag/bugsnag": "^3.29.0",
         "bugsnag/bugsnag-psr-logger": "^1.4|^2.0",
-        "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
         "monolog/monolog": "^1.12|^2.0|^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "monolog/monolog": "^1.12|^2.0|^3.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.1|^4.0|^5.0|^6.0|^7.0",
+        "orchestra/testbench": "^3.1|^4.0|^5.0|^6.0|^7.0|^8.0",
         "phpunit/phpunit": "^4.8.36|^6.3.1|^7.5.15|^8.3.5|^9.3.10"
     },
     "autoload": {


### PR DESCRIPTION
## Goal

This change is necessary so that this package can be installed in Laravel 10 applications

## Changeset

- Added `10.x` to `illuminate` version constraints in composer.json
- Added Laravel 10 to the test suite

## Testing

I ran `make build && make test`