### PR TITLE
Update Maze Runner to v7.18.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.9.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.18.0'

--- a/features/lib/laravel.rb
+++ b/features/lib/laravel.rb
@@ -87,7 +87,7 @@ class Laravel
       # get and parse the composer.lock file from the fixture
       composer_lock = Tempfile.create("#{fixture}-composer.lock") do |file|
         # copy the composer lock file out of the fixture so we can read it
-        Maze::Docker.cp(fixture, source: "/app/composer.lock", destination: file.path)
+        Maze::Docker.copy_from_container(fixture, from: "/app/composer.lock", to: file.path)
 
         # 'file.read' won't reflect the changes made by docker cp, so we use
         # JSON.load_file to reload the file & parse it

--- a/features/steps/laravel_steps.rb
+++ b/features/steps/laravel_steps.rb
@@ -14,27 +14,6 @@ When(/^I start the laravel fixture$/) do
   }
 end
 
-module Maze
-  class Docker
-    class << self
-      # TODO: remove when https://github.com/bugsnag/maze-runner/pull/425 is merged
-      def exec(service, command, detach: false)
-        flags = detach ? "--detach" : ""
-
-        run_docker_compose_command("exec #{flags} #{service} #{command}")
-      end
-
-      # TODO: contribute this back to Maze Runner
-      #       probably need a nicer API, capable of doing a copy in either
-      #       direction (right now this can only copy from the service to the
-      #       local machine)
-      def cp(service, source:, destination:)
-        run_docker_compose_command("cp #{service}:#{source} #{destination}")
-      end
-    end
-  end
-end
-
 When("I start the laravel queue worker") do
   step("I start the laravel queue worker with --tries=1")
 end
@@ -117,26 +96,6 @@ Then("the session payload field {string} matches the current major Lumen version
   end
 
   step("the session payload field '#{path}' matches the regex '^((\\d+\\.){2}\\d+|\\d\\.x-dev)$'")
-end
-
-# TODO: remove when https://github.com/bugsnag/maze-runner/pull/433 is released
-Then("the event has {int} breadcrumb(s)") do |expected|
-  breadcrumbs = Maze::Server.errors.current[:body]['events'].first['breadcrumbs']
-
-  Maze.check.equal(
-    expected,
-    breadcrumbs.length,
-    "Expected event to have '#{expected}' breadcrumbs, but got: #{breadcrumbs}"
-  )
-end
-
-Then("the event has no breadcrumbs") do
-  breadcrumbs = Maze::Server.errors.current[:body]['events'].first['breadcrumbs']
-
-  Maze.check.true(
-    breadcrumbs.nil? || breadcrumbs.empty?,
-    "Expected event not to have breadcrumbs, but got: #{breadcrumbs}"
-  )
 end
 
 # conditionally run a step if the laravel version matches a specified version


### PR DESCRIPTION
## Goal

Update from Maze Runner v7.9.0 to latest (v7.18.0)

This removes some step definitions and functionality that Maze Runner was missing when the queue tests were added in #501, but have since been merged & released