### PR TITLE
Update unstable tests for Laravel 10

### DIFF
--- a/.github/workflows/unstable-version-tests.yml
+++ b/.github/workflows/unstable-version-tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ['8.2']
-        laravel-version: ['9.x-dev', 'dev-master as 9']
+        laravel-version: ['10.x-dev as 10', 'dev-master as 10']
 
     steps:
     - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
       matrix:
         php-version: ['8.2']
         laravel-fixture: [laravel-latest]
-        laravel-version: ['9.x-dev'] #, 'dev-master as 9'] # disabled pending package updates in Laravel's skeleton app (PLAT-7040)
+        laravel-version: ['10.x-dev as 10', 'dev-master as 10']
 
     steps:
     - uses: actions/checkout@v2
@@ -53,7 +53,7 @@ jobs:
     - name: install Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.2'
         bundler-cache: true
 
     - name: install PHP
@@ -62,7 +62,7 @@ jobs:
         php-version: ${{ matrix.php-version }}
         coverage: none
 
-    - run: ./.ci/setup-laravel-dev-fixture.sh ${{ matrix.laravel-version }}
+    - run: ./.ci/setup-laravel-dev-fixture.sh "${{ matrix.laravel-version }}"
 
     - run: bundle exec maze-runner --no-source
       env:

--- a/features/steps/laravel_steps.rb
+++ b/features/steps/laravel_steps.rb
@@ -80,7 +80,7 @@ Then("the event {string} matches the current major Laravel version") do |path|
     step("the event '#{path}' starts with '#{Laravel.major_version}'")
   end
 
-  step("the event '#{path}' matches '^((\\d+\\.){2}\\d+|\\d\\.x-dev)$'")
+  step("the event '#{path}' matches '^((\\d+\\.){2}\\d+|\\d+\\.x-dev)$'")
 end
 
 Then("the session payload field {string} matches the current major Laravel version") do |path|
@@ -92,7 +92,7 @@ Then("the session payload field {string} matches the current major Laravel versi
     step("the session payload field '#{path}' starts with '#{Laravel.major_version}'")
   end
 
-  step("the session payload field '#{path}' matches the regex '^((\\d+\\.){2}\\d+|\\d\\.x-dev)$'")
+  step("the session payload field '#{path}' matches the regex '^((\\d+\\.){2}\\d+|\\d+\\.x-dev)$'")
 end
 
 Then("the event {string} matches the current major Lumen version") do |path|
@@ -104,7 +104,7 @@ Then("the event {string} matches the current major Lumen version") do |path|
     step("the event '#{path}' starts with '#{Laravel.major_version}'")
   end
 
-  step("the event '#{path}' matches '^((\\d+\\.){2}\\d+|\\d\\.x-dev)$'")
+  step("the event '#{path}' matches '^((\\d+\\.){2}\\d+|\\d+\\.x-dev)$'")
 end
 
 Then("the session payload field {string} matches the current major Lumen version") do |path|
@@ -116,7 +116,7 @@ Then("the session payload field {string} matches the current major Lumen version
     step("the session payload field '#{path}' starts with '#{Laravel.major_version}'")
   end
 
-  step("the session payload field '#{path}' matches the regex '^((\\d+\\.){2}\\d+|\\d\\.x-dev)$'")
+  step("the session payload field '#{path}' matches the regex '^((\\d+\\.){2}\\d+|\\d+\\.x-dev)$'")
 end
 
 # TODO: remove when https://github.com/bugsnag/maze-runner/pull/433 is released


### PR DESCRIPTION
## Goal

Updates the unstable tests after Laravel 10's release. This also allowed us to reinstate the Maze Runner tests against their master branch as the skeleton app has been updated

As these tests only run overnight, see https://github.com/bugsnag/bugsnag-laravel/actions/runs/4184886979 for a successful run