### PR TITLE
Fix unstable tests

### DIFF
--- a/.ci/patches/register-service-provider-and-facade.patch
+++ b/.ci/patches/register-service-provider-and-facade.patch
@@ -14,7 +14,7 @@ index 1941d7c..039b0d4 100644
      */
  
      'aliases' => Facade::defaultAliases()->merge([
--        // 'ExampleClass' => App\Example\ExampleClass::class,
+-        // 'Example' => App\Facades\Example::class,
 +        'Bugsnag' => Bugsnag\BugsnagLaravel\Facades\Bugsnag::class,
      ])->toArray(),
  


### PR DESCRIPTION
## Goal

An example changed in https://github.com/laravel/laravel/pull/6159, which stopped one of our patches from applying as it directly edits that line

See:

- failed run on `master`: https://github.com/bugsnag/bugsnag-laravel/actions/runs/4738163181/jobs/8411730298
- successful run on this branch: https://github.com/bugsnag/bugsnag-laravel/actions/runs/4742763769/jobs/8421435089