### PR TITLE
Implement Laravel's Automatic Package Discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,14 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.18-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Bugsnag\\BugsnagLaravel\\BugsnagServiceProvider"
+            ],
+            "aliases": {
+                "Bugsnag": "Bugsnag\\BugsnagLaravel\\Facades\\Bugsnag"
+            }
         }
     },
     "scripts": {


### PR DESCRIPTION
Updates compose.json to use the Laravel Package Discovery feature eliminating the need to manually add the BugSnagServiceProvider and/or Facade to their respective arrays in `config/app.php`. You should also change the documentation regarding the onboard/installation process for Laravel apps.

## Goal

Reduces the onboarding process to a near zero config setup

## Design

Laravel has allowed package discovery since v5.5 released in August 2017.

## Changeset

composer.json extras/laravel added

## Testing

No tests necessary to implement this change.