### PR TITLE
Attach Laravel's Context to events as metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Attach Laravel 11's `Context` to events as metadata under the key 'Laravel Context'. Hidden context will only be added if the new configuration option `attach_hidden_context` is enabled, either in `config/bugsnag.php` or via the environment variable `BUGSNAG_ATTACH_HIDDEN_CONTEXT`
+  [#537](https://github.com/bugsnag/bugsnag-laravel/pull/537)
+
 ## v2.27.0 (2024-03-13)
 
 ### Enhancements

--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -358,7 +358,19 @@ return [
     | The maximum number of breadcrumbs to send with a report.
     |
     | This should be an integer between 0-100 (inclusive).
+    |
     */
 
     'max_breadcrumbs' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Attach hidden context
+    |--------------------------------------------------------------------------
+    |
+    | Whether to attach hidden Context data to events as metadata.
+    |
+    */
+
+    'attach_hidden_context' => env('BUGSNAG_ATTACH_HIDDEN_CONTEXT', false),
 ];

--- a/src/BugsnagServiceProvider.php
+++ b/src/BugsnagServiceProvider.php
@@ -25,6 +25,7 @@ use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Context;
 use Laravel\Lumen\Application as LumenApplication;
 use Monolog\Handler\PsrHandler;
 use Monolog\Logger;
@@ -438,6 +439,27 @@ class BugsnagServiceProvider extends ServiceProvider
                     }
                 }
             }));
+        }
+
+        // Laravel 11 has a 'Context' class for storing metadata
+        // https://laravel.com/docs/11.x/context
+        if (class_exists(Context::class)) {
+            $client->registerCallback(function (Report $report) {
+                $context = Context::all();
+
+                $report->setMetaData(['Laravel Context' => $context]);
+            });
+
+            // only attach hidden context if enabled, otherwise sensitive data
+            // could leak to bugsnag
+            if (isset($config['attach_hidden_context']) && $config['attach_hidden_context']) {
+                $client->registerCallback(function (Report $report) {
+                    $hiddenContext = Context::allHidden();
+
+                    $report->setMetaData(['Laravel Hidden Context' => $hiddenContext]);
+                });
+
+            }
         }
     }
 

--- a/tests/Middleware/UnhandledStateTest.php
+++ b/tests/Middleware/UnhandledStateTest.php
@@ -8,7 +8,11 @@ use Bugsnag\BugsnagLaravel\Tests\Stubs\DebugBacktraceStub;
 
 function debug_backtrace()
 {
-    return DebugBacktraceStub::get();
+    if (DebugBacktraceStub::hasValue()) {
+        return DebugBacktraceStub::get();
+    }
+
+    return \debug_backtrace();
 }
 
 namespace Bugsnag\BugsnagLaravel\Tests\Middleware;

--- a/tests/Stubs/DebugBacktraceStub.php
+++ b/tests/Stubs/DebugBacktraceStub.php
@@ -25,6 +25,11 @@ class DebugBacktraceStub
         self::$backtrace = $backtrace;
     }
 
+    public static function hasValue()
+    {
+        return self::$backtrace !== [];
+    }
+
     public static function clear()
     {
         self::$backtrace = [];


### PR DESCRIPTION
## Goal

Laravel 11 added a new `Context` feature that allows adding arbitrary metadata to its logging system

This PR adds support for reading from the `Context` and attaching it to events as metadata

There is a new configuration option, `attach_hidden_context` (or environment variable `BUGSNAG_ATTACH_HIDDEN_CONTEXT`), that controls whether ["hidden context"](https://laravel.com/docs/11.x/context#hidden-context) is added as metadata as well. This is disabled by default to avoid accidentally leaking data

See also #536 & https://laravel.com/docs/11.x/context