### PR TITLE
updated memory limit in fixture

### DIFF
--- a/features/fixtures/laravel11/bootstrap/app.php
+++ b/features/fixtures/laravel11/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Foundation\Application;
 use Bugsnag\BugsnagLaravel\OomBootstrapper;
+use Bugsnag\BugsnagLaravel\Facades\Bugsnag;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 
@@ -23,4 +24,8 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //
-    })->create();
+    })
+    ->booted(function(){
+        Bugsnag::setMemoryLimitIncrease($value = 6 * 1024 * 1024);
+    })
+    ->create();

--- a/features/fixtures/laravel11/routes/web.php
+++ b/features/fixtures/laravel11/routes/web.php
@@ -75,7 +75,10 @@ Route::get('/oom/big', function () {
 });
 
 Route::get('/oom/small', function () {
-    ini_set('memory_limit', memory_get_usage() + (1024 * 1024 * 5));
+    // The 5 MiB default limit is not enough to
+    // deliver the OOM error in this scenario.
+    Bugsnag::setMemoryLimitIncrease(1024 * 1024 * 6); // 6 MiB
+    ini_set('memory_limit', memory_get_usage() + (1024 * 1024 * 5)); // 5 MiB
     ini_set('display_errors', true);
 
     $i = 0;

--- a/features/fixtures/laravel11/routes/web.php
+++ b/features/fixtures/laravel11/routes/web.php
@@ -75,10 +75,7 @@ Route::get('/oom/big', function () {
 });
 
 Route::get('/oom/small', function () {
-    // The 5 MiB default limit is not enough to
-    // deliver the OOM error in this scenario.
-    Bugsnag::setMemoryLimitIncrease(1024 * 1024 * 6); // 6 MiB
-    ini_set('memory_limit', memory_get_usage() + (1024 * 1024 * 5)); // 5 MiB
+    ini_set('memory_limit', memory_get_usage() + (1024 * 1024 * 5));
     ini_set('display_errors', true);
 
     $i = 0;


### PR DESCRIPTION
## Goal

Recently, the "small OOM" test for the `laravel11` fixture started to fail. This change aims to resolve the issue.

## Changeset

- Increased the amount of memory BugSnag notifier reserves from 5 MiB to 6MiB in the `laravel11` fixture.