### PR TITLE
Remove PHP 8.4 deprecations and update test matrices

### DIFF
--- a/.github/workflows/maze-runner-tests.yml
+++ b/.github/workflows/maze-runner-tests.yml
@@ -29,6 +29,8 @@ jobs:
             laravel-fixture: laravel10
           - php-version: '8.3'
             laravel-fixture: laravel11
+          - php-version: '8.4'
+            laravel-fixture: laravel11
           - php-version: '8.0'
             laravel-fixture: lumen8
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -112,6 +112,8 @@ jobs:
             laravel-version: '10.*'
           - php-version: '8.3'
             laravel-version: '11.*'
+          - php-version: '8.4'
+            laravel-version: '11.*'
 
     steps:
     - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -10,20 +10,10 @@
             "email": "notifiers@bugsnag.com"
         }
     ],
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/bugsnag/bugsnag-php"
-        },
-        {
-            "type": "git",
-            "url": "https://github.com/bugsnag/bugsnag-psr-logger"
-        }
-    ],
     "require": {
         "php": ">=5.5",
-        "bugsnag/bugsnag": "dev-next",
-        "bugsnag/bugsnag-psr-logger": "dev-next",
+        "bugsnag/bugsnag": "^3.29.0",
+        "bugsnag/bugsnag-psr-logger": "^1.4|^2.0",
         "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "monolog/monolog": "^1.12|^2.0|^3.0"

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,16 @@
         {
             "type": "git",
             "url": "https://github.com/bugsnag/bugsnag-php"
+        },
+        {
+            "type": "git",
+            "url": "https://github.com/bugsnag/bugsnag-psr-logger"
         }
     ],
     "require": {
         "php": ">=5.5",
         "bugsnag/bugsnag": "dev-next",
-        "bugsnag/bugsnag-psr-logger": "^1.4|^2.0",
+        "bugsnag/bugsnag-psr-logger": "dev-next",
         "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "monolog/monolog": "^1.12|^2.0|^3.0"

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,15 @@
             "email": "notifiers@bugsnag.com"
         }
     ],
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/bugsnag/bugsnag-php"
+        }
+    ],
     "require": {
         "php": ">=5.5",
-        "bugsnag/bugsnag": "^3.29.0",
+        "bugsnag/bugsnag": "dev-next",
         "bugsnag/bugsnag-psr-logger": "^1.4|^2.0",
         "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",

--- a/src/LaravelLogger.php
+++ b/src/LaravelLogger.php
@@ -21,7 +21,7 @@ class LaravelLogger extends BugsnagLogger implements Log
      *
      * @return void
      */
-    public function __construct(Client $client, Dispatcher $dispatcher = null)
+    public function __construct(Client $client, $dispatcher = null)
     {
         parent::__construct($client);
 

--- a/src/MultiLogger.php
+++ b/src/MultiLogger.php
@@ -18,7 +18,7 @@ class MultiLogger extends BaseLogger implements Log
      *
      * @return void
      */
-    public function __construct(array $loggers, Dispatcher $dispatcher = null)
+    public function __construct(array $loggers, $dispatcher = null)
     {
         parent::__construct($loggers);
 


### PR DESCRIPTION
## Goal

This follows the changes made to the main PHP notifier in removing type annotations in method signatures that will cause deprecation warnings in PHP 8.4.  It also adds PHP 8.4 to the test matrices to ensure we have coverage when required.

A check was also made for E_STRICT instances, but none were found.

This hasn't required any changes in the PSR-logger, so that will remain unchanged.

## Tests

It may be difficult for CI to run through until the new version of the PHP notifier is released, however I've run through all of the test scenarios locally, they all passed, and there were no deprecation warnings during testing.