### PR TITLE
Add octane tests to laravel 12

### DIFF
--- a/.github/workflows/maze-runner-tests.yml
+++ b/.github/workflows/maze-runner-tests.yml
@@ -67,6 +67,8 @@ jobs:
         include:
           - php-version: '8.4'
             laravel-fixture: laravel11
+          - php-version: '8.4'
+            laravel-fixture: laravel12
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.idea
 Gemfile.lock
 maze_output
+maze-runner.log
 .phpunit.result.cache
 /features/fixtures/*/bugsnag-laravel
 /features/fixtures/laravel-latest/*

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -163,7 +163,7 @@ services:
 
   laravelrr:
     build:
-      context: laravel11
+      context: ${LARAVEL_FIXTURE}
       dockerfile: Dockerfile-roadrunner
       args:
         - PHP_VERSION
@@ -180,11 +180,11 @@ services:
     restart: "no"
     ports:
       - target: 8000
-        published: 61311 # must be the same as laravel11
+        published: ${LARAVEL_FIXTURE_PORT} # must be the same as laravel11
 
   laravelfp:
     build:
-      context: laravel11
+      context: ${LARAVEL_FIXTURE}
       dockerfile: Dockerfile-frankenphp
       args:
         - PHP_VERSION
@@ -201,11 +201,11 @@ services:
     restart: "no"
     ports:
       - target: 8000
-        published: 61311  # must be the same as laravel11
+        published: ${LARAVEL_FIXTURE_PORT}  # must be the same as laravel11
 
   laravelsw:
     build:
-      context: laravel11
+      context: ${LARAVEL_FIXTURE}
       dockerfile: Dockerfile-swoole
       args:
         - PHP_VERSION
@@ -222,7 +222,7 @@ services:
     restart: "no"
     ports:
       - target: 8000
-        published: 61311  # must be the same as laravel11
+        published: ${LARAVEL_FIXTURE_PORT}  # must be the same as laravel11
 
   laravel12:
     build:

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -163,7 +163,7 @@ services:
 
   laravelrr:
     build:
-      context: ${LARAVEL_FIXTURE}
+      context: ${LARAVEL_FIXTURE} # Set to the base test fixture e.g. laravel11
       dockerfile: Dockerfile-roadrunner
       args:
         - PHP_VERSION
@@ -180,11 +180,11 @@ services:
     restart: "no"
     ports:
       - target: 8000
-        published: ${LARAVEL_FIXTURE_PORT} # must be the same as laravel11
+        published: ${LARAVEL_FIXTURE_PORT} # Set to the published port of the base test fixture
 
   laravelfp:
     build:
-      context: ${LARAVEL_FIXTURE}
+      context: ${LARAVEL_FIXTURE} # Set to the base test fixture e.g. laravel11
       dockerfile: Dockerfile-frankenphp
       args:
         - PHP_VERSION
@@ -201,11 +201,11 @@ services:
     restart: "no"
     ports:
       - target: 8000
-        published: ${LARAVEL_FIXTURE_PORT}  # must be the same as laravel11
+        published: ${LARAVEL_FIXTURE_PORT} # Set to the published port of the base test fixture
 
   laravelsw:
     build:
-      context: ${LARAVEL_FIXTURE}
+      context: ${LARAVEL_FIXTURE} # Set to the base test fixture e.g. laravel11
       dockerfile: Dockerfile-swoole
       args:
         - PHP_VERSION
@@ -222,7 +222,7 @@ services:
     restart: "no"
     ports:
       - target: 8000
-        published: ${LARAVEL_FIXTURE_PORT}  # must be the same as laravel11
+        published: ${LARAVEL_FIXTURE_PORT} # Set to the published port of the base test fixture
 
   laravel12:
     build:

--- a/features/fixtures/laravel12/Dockerfile-frankenphp
+++ b/features/fixtures/laravel12/Dockerfile-frankenphp
@@ -1,0 +1,29 @@
+ARG PHP_VERSION
+FROM php:$PHP_VERSION
+
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  git \
+  unzip \
+  wget \
+  zip
+
+WORKDIR /app
+
+COPY . .
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
+
+RUN curl https://frankenphp.dev/install.sh | sh
+RUN mv frankenphp /usr/local/bin/
+
+RUN cp .env.example .env
+RUN docker-php-ext-install sockets pcntl posix
+RUN composer install --no-dev
+RUN composer require laravel/octane
+RUN php artisan key:generate
+RUN php artisan octane:install --server=frankenphp
+
+# create database & apply migrations
+RUN touch database/database.sqlite && php artisan migrate --no-interaction
+
+CMD php -d variables_order=EGPCS artisan octane:start --server=frankenphp --host=0.0.0.0 --admin-port=2019 --port=8000

--- a/features/fixtures/laravel12/Dockerfile-roadrunner
+++ b/features/fixtures/laravel12/Dockerfile-roadrunner
@@ -1,0 +1,27 @@
+ARG PHP_VERSION
+FROM php:$PHP_VERSION
+
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  git \
+  unzip \
+  wget \
+  zip
+
+WORKDIR /app
+
+COPY . .
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
+
+RUN cp .env.example .env
+RUN docker-php-ext-install sockets pcntl posix
+RUN composer install --no-dev
+RUN composer require laravel/octane spiral/roadrunner-cli
+RUN ./vendor/bin/rr get-binary
+RUN php artisan key:generate
+RUN php artisan octane:install --server=roadrunner
+
+# create database & apply migrations
+RUN touch database/database.sqlite && php artisan migrate --no-interaction
+
+CMD php -d variables_order=EGPCS artisan octane:start --server=roadrunner --host=0.0.0.0 --rpc-port=6001 --port=8000

--- a/features/fixtures/laravel12/Dockerfile-swoole
+++ b/features/fixtures/laravel12/Dockerfile-swoole
@@ -1,0 +1,29 @@
+ARG PHP_VERSION
+FROM php:$PHP_VERSION
+
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  git \
+  unzip \
+  wget \
+  zip \
+  libbrotli-dev
+
+WORKDIR /app
+
+COPY . .
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
+
+RUN cp .env.example .env
+RUN docker-php-ext-install sockets pcntl posix
+RUN composer install --no-dev
+RUN composer require laravel/octane
+RUN pecl install swoole
+RUN docker-php-ext-enable swoole
+RUN php artisan key:generate
+RUN php artisan octane:install --server=swoole
+
+# create database & apply migrations
+RUN touch database/database.sqlite && php artisan migrate --no-interaction
+
+CMD php -d variables_order=EGPCS artisan octane:start --server=swoole --host=0.0.0.0 --rpc-port=6001 --port=8000

--- a/features/octane/handled_controller.feature
+++ b/features/octane/handled_controller.feature
@@ -1,8 +1,7 @@
 Feature: Handled exceptions in controllers support
 
 Scenario Outline: Handled exceptions are delivered from controllers
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  Given I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/handled_controller_exception"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -24,8 +23,7 @@ Scenario Outline: Handled exceptions are delivered from controllers
 
 Scenario Outline: Handled errors are delivered from controllers
   Given I set environment variable "BUGSNAG_OCTANE_BREADCRUMBS" to "false"
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  And I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/handled_controller_error"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -48,8 +46,7 @@ Scenario Outline: Handled errors are delivered from controllers
 @requires-sessions
 Scenario Outline: Sessions are correct in handled exceptions from controllers
   Given I enable session tracking
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  And I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/handled_controller_exception"
   And I wait to receive a session
   Then the session is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier

--- a/features/octane/handled_middleware.feature
+++ b/features/octane/handled_middleware.feature
@@ -1,8 +1,7 @@
 Feature: Handled exceptions for middleware support
 
 Scenario Outline: Handled exceptions are delivered from middleware
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  Given I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/handled_middleware_exception"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -22,8 +21,7 @@ Scenario Outline: Handled exceptions are delivered from middleware
     | "laravelsw" |
 
 Scenario Outline: Handled errors are delivered from middleware
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  Given I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/handled_middleware_error"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -45,8 +43,7 @@ Scenario Outline: Handled errors are delivered from middleware
 @requires-sessions
 Scenario Outline: Sessions are correct in handled exceptions from middleware
   Given I enable session tracking
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  And I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/handled_middleware_exception"
   And I wait to receive a session
   Then the session is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier

--- a/features/octane/handled_routing.feature
+++ b/features/octane/handled_routing.feature
@@ -1,8 +1,7 @@
 Feature: Handled exceptions from routing support
 
 Scenario Outline: Handled exceptions are delivered from routing
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  Given I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/handled_exception"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -22,8 +21,7 @@ Scenario Outline: Handled exceptions are delivered from routing
     | "laravelsw" |
 
 Scenario Outline: Handled errors are delivered from routing
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  Given I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/handled_error"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -45,8 +43,7 @@ Scenario Outline: Handled errors are delivered from routing
 @requires-sessions
 Scenario Outline: Sessions are correct in handled exceptions from routing
   Given I enable session tracking
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  And I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/handled_exception"
   And I wait to receive a session
   Then the session is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier

--- a/features/octane/handled_view.feature
+++ b/features/octane/handled_view.feature
@@ -1,8 +1,7 @@
 Feature: Handled exceptions for views support
 
 Scenario Outline: Handled exceptions are delivered from views
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  Given I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/handled_view_exception"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -22,8 +21,7 @@ Scenario Outline: Handled exceptions are delivered from views
     | "laravelsw" |
 
 Scenario Outline: Handled errors are delivered from views
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  Given I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/handled_view_error"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -45,8 +43,7 @@ Scenario Outline: Handled errors are delivered from views
 @requires-sessions
 Scenario Outline: Sessions are correct in Handled exceptions from views
   Given I enable session tracking
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  And I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/handled_view_exception"
   And I wait to receive a session
   Then the session is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier

--- a/features/octane/unhandled_controller.feature
+++ b/features/octane/unhandled_controller.feature
@@ -1,8 +1,7 @@
 Feature: Unhandled exceptions in controllers support
 
 Scenario Outline: Unhandled exceptions are delivered from controllers
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  Given I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/unhandled_controller_exception"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -23,8 +22,7 @@ Scenario Outline: Unhandled exceptions are delivered from controllers
     | "laravelsw" |
 
 Scenario Outline: Unhandled errors are delivered from controllers
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  Given I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/unhandled_controller_error"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -48,8 +46,7 @@ Scenario Outline: Unhandled errors are delivered from controllers
 @requires-sessions
 Scenario Outline: Sessions are correct in unhandled exceptions from controllers
   Given I enable session tracking
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  And I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/unhandled_controller_exception"
   And I wait to receive a session
   Then the session is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier

--- a/features/octane/unhandled_middleware.feature
+++ b/features/octane/unhandled_middleware.feature
@@ -1,8 +1,7 @@
 Feature: Unhandled exceptions for middleware support
 
 Scenario Outline: Unhandled exceptions are delivered from middleware
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  Given I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/unhandled_middleware_exception"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -23,8 +22,7 @@ Scenario Outline: Unhandled exceptions are delivered from middleware
     | "laravelsw" |
 
 Scenario Outline: Unhandled errors are delivered from middleware
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  Given I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/unhandled_middleware_error"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -48,8 +46,7 @@ Scenario Outline: Unhandled errors are delivered from middleware
 @requires-sessions
 Scenario Outline: Sessions are correct in unhandled exceptions from middleware
   Given I enable session tracking
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  And I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/unhandled_middleware_exception"
   And I wait to receive a session
   Then the session is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier

--- a/features/octane/unhandled_routing.feature
+++ b/features/octane/unhandled_routing.feature
@@ -1,8 +1,7 @@
 Feature: Unhandled exceptions for routing support
 
 Scenario Outline: Unhandled exceptions are delivered from routing
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  Given I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/unhandled_exception"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -23,8 +22,7 @@ Scenario Outline: Unhandled exceptions are delivered from routing
     | "laravelsw" |
 
 Scenario Outline: Unhandled errors are delivered from routing
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  Given I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/unhandled_error"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -47,8 +45,7 @@ Scenario Outline: Unhandled errors are delivered from routing
 @requires-sessions
 Scenario Outline: Sessions are correct in unhandled exceptions from routing
   Given I enable session tracking
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  And I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/unhandled_exception"
   And I wait to receive a session
   Then the session is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier

--- a/features/octane/unhandled_view.feature
+++ b/features/octane/unhandled_view.feature
@@ -1,8 +1,7 @@
 Feature: Unhandled exceptions for views support
 
 Scenario Outline: Unhandled exceptions are delivered from views
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  Given I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/unhandled_view_exception"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -27,8 +26,7 @@ Scenario Outline: Unhandled exceptions are delivered from views
     | "laravelsw" |
 
 Scenario Outline: Unhandled errors are delivered from views
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  Given I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/unhandled_view_error"
   Then I wait to receive an error
   And the error is valid for the error reporting API version "4.0" for the "Bugsnag Laravel" notifier
@@ -55,8 +53,7 @@ Scenario Outline: Unhandled errors are delivered from views
 @requires-sessions
 Scenario Outline: Sessions are correct in unhandled exceptions from views
   Given I enable session tracking
-  When I start the service <octanesrv>
-  And I wait for the host "localhost" to open port "61311"
+  And I start the laravel octane fixture <octanesrv>
   When I navigate to the route "/unhandled_view_exception"
   And I wait to receive a session
   Then the session is valid for the session reporting API version "1.0" for the "Bugsnag Laravel" notifier

--- a/features/steps/laravel_steps.rb
+++ b/features/steps/laravel_steps.rb
@@ -14,6 +14,13 @@ When(/^I start the laravel fixture$/) do
   }
 end
 
+When("I start the laravel octane fixture {string}") do |fixture|
+  steps %{
+    When I start the service "#{fixture}"
+    And I wait for the host "localhost" to open port "#{Laravel.fixture_port}"
+  }
+end
+
 When("I start the laravel queue worker") do
   step("I start the laravel queue worker with --tries=1")
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -33,6 +33,7 @@ Maze.hooks.before do
   Maze::Runner.environment["BUGSNAG_API_KEY"] = $api_key
   Maze::Runner.environment["BUGSNAG_ENDPOINT"] = "http://#{Utils.current_ip}:#{Maze.config.port}/notify"
   Maze::Runner.environment["BUGSNAG_SESSION_ENDPOINT"] = "http://#{Utils.current_ip}:#{Maze.config.port}/sessions"
+  Maze::Runner.environment['LARAVEL_FIXTURE_PORT'] = Laravel.fixture_port.to_s
   Laravel.reset!
 end
 


### PR DESCRIPTION
## Goal

Runs our octane tests using the laravel 12 test fixture, as well as updating the docker files to allow us to add octane to other fixtures in the future.