### PR TITLE
Add parameters to octane testing

### DIFF
--- a/.github/workflows/maze-runner-tests.yml
+++ b/.github/workflows/maze-runner-tests.yml
@@ -66,8 +66,10 @@ jobs:
       matrix:
         include:
           - php-version: '8.4'
+            octane-version: '2.8.2'
             laravel-fixture: laravel11
           - php-version: '8.4'
+            octane-version: '2.8.2'
             laravel-fixture: laravel12
 
     steps:
@@ -88,5 +90,6 @@ jobs:
     - run: bundle exec maze-runner --no-source ./features/octane
       env:
         PHP_VERSION: ${{ matrix.php-version }}
+        OCTANE_VERSION: ${{ matrix.octane-version }}
         LARAVEL_FIXTURE: ${{ matrix.laravel-fixture }}
         COMPOSER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -168,6 +168,7 @@ services:
       args:
         - PHP_VERSION
         - OCTANE_VERSION=${OCTANE_VERSION:-2.8.2}
+        - ROADRUNNER_VERSION=${ROADRUNNER_VERSION:-v2024.3.5}
     environment:
       - BUGSNAG_API_KEY
       - BUGSNAG_ENDPOINT

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -167,6 +167,7 @@ services:
       dockerfile: Dockerfile-roadrunner
       args:
         - PHP_VERSION
+        - OCTANE_VERSION=${OCTANE_VERSION:-2.8.2}
     environment:
       - BUGSNAG_API_KEY
       - BUGSNAG_ENDPOINT

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -188,6 +188,7 @@ services:
       dockerfile: Dockerfile-frankenphp
       args:
         - PHP_VERSION
+        - OCTANE_VERSION=${OCTANE_VERSION:-2.8.2}
     environment:
       - BUGSNAG_API_KEY
       - BUGSNAG_ENDPOINT
@@ -209,6 +210,7 @@ services:
       dockerfile: Dockerfile-swoole
       args:
         - PHP_VERSION
+        - OCTANE_VERSION=${OCTANE_VERSION:-2.8.2}
     environment:
       - BUGSNAG_API_KEY
       - BUGSNAG_ENDPOINT
@@ -229,6 +231,7 @@ services:
       context: laravel12
       args:
         - PHP_VERSION
+        - OCTANE_VERSION=${OCTANE_VERSION:-2.8.2}
     environment:
       - BUGSNAG_API_KEY
       - BUGSNAG_ENDPOINT

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -235,7 +235,6 @@ services:
       context: laravel12
       args:
         - PHP_VERSION
-        - OCTANE_VERSION=${OCTANE_VERSION:-2.8.2}
     environment:
       - BUGSNAG_API_KEY
       - BUGSNAG_ENDPOINT

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -168,7 +168,7 @@ services:
       args:
         - PHP_VERSION
         - OCTANE_VERSION=${OCTANE_VERSION:-2.8.2}
-        - ROADRUNNER_VERSION=${ROADRUNNER_VERSION:-v2024.3.5}
+        - ROADRUNNER_VERSION=${ROADRUNNER_VERSION:-v2.7.1}
     environment:
       - BUGSNAG_API_KEY
       - BUGSNAG_ENDPOINT

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -191,6 +191,7 @@ services:
       args:
         - PHP_VERSION
         - OCTANE_VERSION=${OCTANE_VERSION:-2.8.2}
+        - FRANKENPHP_VERSION=${FRANKENPHP_VERSION:-v1.4.4}
     environment:
       - BUGSNAG_API_KEY
       - BUGSNAG_ENDPOINT

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -168,7 +168,7 @@ services:
       args:
         - PHP_VERSION
         - OCTANE_VERSION=${OCTANE_VERSION:-2.8.2}
-        - ROADRUNNER_VERSION=${ROADRUNNER_VERSION:-v2.7.1}
+        - ROADRUNNER_CLI_VERSION=${ROADRUNNER_CLI_VERSION:-v2.7.1}
     environment:
       - BUGSNAG_API_KEY
       - BUGSNAG_ENDPOINT

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -211,6 +211,7 @@ services:
       args:
         - PHP_VERSION
         - OCTANE_VERSION=${OCTANE_VERSION:-2.8.2}
+        - SWOOLE_VERSION=${SWOOLE_VERSION:-6.0.1}
     environment:
       - BUGSNAG_API_KEY
       - BUGSNAG_ENDPOINT

--- a/features/fixtures/laravel11/Dockerfile-frankenphp
+++ b/features/fixtures/laravel11/Dockerfile-frankenphp
@@ -13,7 +13,8 @@ WORKDIR /app
 COPY . .
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
-RUN curl https://frankenphp.dev/install.sh | sh
+ARG FRANKENPHP_VERSION
+RUN curl -L "https://github.com/dunglas/frankenphp/releases/tag/${FRANKENPHP_VERSION}/download/frankenphp-linux-aarch64" -o "/app/frankenphp"
 RUN mv frankenphp /usr/local/bin/
 
 RUN cp .env.example .env

--- a/features/fixtures/laravel11/Dockerfile-frankenphp
+++ b/features/fixtures/laravel11/Dockerfile-frankenphp
@@ -19,7 +19,10 @@ RUN mv frankenphp /usr/local/bin/
 RUN cp .env.example .env
 RUN docker-php-ext-install sockets pcntl posix
 RUN composer install --no-dev
-RUN composer require laravel/octane
+
+ARG OCTANE_VERSION
+
+RUN composer require laravel/octane:$OCTANE_VERSION
 RUN php artisan key:generate
 RUN php artisan octane:install --server=frankenphp
 

--- a/features/fixtures/laravel11/Dockerfile-roadrunner
+++ b/features/fixtures/laravel11/Dockerfile-roadrunner
@@ -16,7 +16,11 @@ COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 RUN cp .env.example .env
 RUN docker-php-ext-install sockets pcntl posix
 RUN composer install --no-dev
-RUN composer require laravel/octane spiral/roadrunner-cli
+
+ARG OCTANE_VERSION
+RUN composer require laravel/octane:$OCTANE_VERSION
+
+RUN composer require spiral/roadrunner-cli
 RUN ./vendor/bin/rr get-binary
 RUN php artisan key:generate
 RUN php artisan octane:install --server=roadrunner

--- a/features/fixtures/laravel11/Dockerfile-roadrunner
+++ b/features/fixtures/laravel11/Dockerfile-roadrunner
@@ -20,8 +20,8 @@ RUN composer install --no-dev
 ARG OCTANE_VERSION
 RUN composer require laravel/octane:$OCTANE_VERSION
 
-ARG ROADRUNNER_VERSION
-RUN composer require spiral/roadrunner-cli:$ROADRUNNER_VERSION
+ARG ROADRUNNER_CLI_VERSION
+RUN composer require spiral/roadrunner-cli:$ROADRUNNER_CLI_VERSION
 
 RUN ./vendor/bin/rr get-binary
 RUN php artisan key:generate

--- a/features/fixtures/laravel11/Dockerfile-roadrunner
+++ b/features/fixtures/laravel11/Dockerfile-roadrunner
@@ -20,7 +20,9 @@ RUN composer install --no-dev
 ARG OCTANE_VERSION
 RUN composer require laravel/octane:$OCTANE_VERSION
 
-RUN composer require spiral/roadrunner-cli
+ARG ROADRUNNER_VERSION
+RUN composer require spiral/roadrunner-cli:$ROADRUNNER_VERSION
+
 RUN ./vendor/bin/rr get-binary
 RUN php artisan key:generate
 RUN php artisan octane:install --server=roadrunner

--- a/features/fixtures/laravel11/Dockerfile-swoole
+++ b/features/fixtures/laravel11/Dockerfile-swoole
@@ -21,7 +21,9 @@ RUN composer install --no-dev
 ARG OCTANE_VERSION
 RUN composer require laravel/octane:$OCTANE_VERSION
 
-RUN pecl install swoole
+ARG SWOOLE_VERSION
+RUN pecl install swoole-$SWOOLE_VERSION
+
 RUN docker-php-ext-enable swoole
 RUN php artisan key:generate
 RUN php artisan octane:install --server=swoole

--- a/features/fixtures/laravel11/Dockerfile-swoole
+++ b/features/fixtures/laravel11/Dockerfile-swoole
@@ -17,7 +17,10 @@ COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 RUN cp .env.example .env
 RUN docker-php-ext-install sockets pcntl posix
 RUN composer install --no-dev
-RUN composer require laravel/octane
+
+ARG OCTANE_VERSION
+RUN composer require laravel/octane:$OCTANE_VERSION
+
 RUN pecl install swoole
 RUN docker-php-ext-enable swoole
 RUN php artisan key:generate

--- a/features/fixtures/laravel12/Dockerfile-frankenphp
+++ b/features/fixtures/laravel12/Dockerfile-frankenphp
@@ -13,7 +13,8 @@ WORKDIR /app
 COPY . .
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
-RUN curl https://frankenphp.dev/install.sh | sh
+ARG FRANKENPHP_VERSION
+RUN curl -L "https://github.com/dunglas/frankenphp/releases/tag/${FRANKENPHP_VERSION}/download/frankenphp-linux-aarch64" -o "/app/frankenphp"
 RUN mv frankenphp /usr/local/bin/
 
 RUN cp .env.example .env

--- a/features/fixtures/laravel12/Dockerfile-frankenphp
+++ b/features/fixtures/laravel12/Dockerfile-frankenphp
@@ -19,7 +19,10 @@ RUN mv frankenphp /usr/local/bin/
 RUN cp .env.example .env
 RUN docker-php-ext-install sockets pcntl posix
 RUN composer install --no-dev
-RUN composer require laravel/octane
+
+ARG OCTANE_VERSION
+RUN composer require laravel/octane:$OCTANE_VERSION
+
 RUN php artisan key:generate
 RUN php artisan octane:install --server=frankenphp
 

--- a/features/fixtures/laravel12/Dockerfile-roadrunner
+++ b/features/fixtures/laravel12/Dockerfile-roadrunner
@@ -16,7 +16,11 @@ COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 RUN cp .env.example .env
 RUN docker-php-ext-install sockets pcntl posix
 RUN composer install --no-dev
-RUN composer require laravel/octane spiral/roadrunner-cli
+
+ARG OCTANE_VERSION
+RUN composer require laravel/octane:$OCTANE_VERSION
+
+RUN composer require spiral/roadrunner-cli
 RUN ./vendor/bin/rr get-binary
 RUN php artisan key:generate
 RUN php artisan octane:install --server=roadrunner

--- a/features/fixtures/laravel12/Dockerfile-roadrunner
+++ b/features/fixtures/laravel12/Dockerfile-roadrunner
@@ -20,8 +20,8 @@ RUN composer install --no-dev
 ARG OCTANE_VERSION
 RUN composer require laravel/octane:$OCTANE_VERSION
 
-ARG ROADRUNNER_VERSION
-RUN composer require spiral/roadrunner-cli:$ROADRUNNER_VERSION
+ARG ROADRUNNER_CLI_VERSION
+RUN composer require spiral/roadrunner-cli:$ROADRUNNER_CLI_VERSION
 
 RUN ./vendor/bin/rr get-binary
 RUN php artisan key:generate

--- a/features/fixtures/laravel12/Dockerfile-roadrunner
+++ b/features/fixtures/laravel12/Dockerfile-roadrunner
@@ -20,7 +20,9 @@ RUN composer install --no-dev
 ARG OCTANE_VERSION
 RUN composer require laravel/octane:$OCTANE_VERSION
 
-RUN composer require spiral/roadrunner-cli
+ARG ROADRUNNER_VERSION
+RUN composer require spiral/roadrunner-cli:$ROADRUNNER_VERSION
+
 RUN ./vendor/bin/rr get-binary
 RUN php artisan key:generate
 RUN php artisan octane:install --server=roadrunner

--- a/features/fixtures/laravel12/Dockerfile-swoole
+++ b/features/fixtures/laravel12/Dockerfile-swoole
@@ -21,7 +21,9 @@ RUN composer install --no-dev
 ARG OCTANE_VERSION
 RUN composer require laravel/octane:$OCTANE_VERSION
 
-RUN pecl install swoole
+ARG SWOOLE_VERSION
+RUN pecl install swoole-$SWOOLE_VERSION
+
 RUN docker-php-ext-enable swoole
 RUN php artisan key:generate
 RUN php artisan octane:install --server=swoole

--- a/features/fixtures/laravel12/Dockerfile-swoole
+++ b/features/fixtures/laravel12/Dockerfile-swoole
@@ -17,7 +17,10 @@ COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 RUN cp .env.example .env
 RUN docker-php-ext-install sockets pcntl posix
 RUN composer install --no-dev
-RUN composer require laravel/octane
+
+ARG OCTANE_VERSION
+RUN composer require laravel/octane:$OCTANE_VERSION
+
 RUN pecl install swoole
 RUN docker-php-ext-enable swoole
 RUN php artisan key:generate


### PR DESCRIPTION
## Goal

Parameterises the versions used in octane testing to allow us to add more test coverage for future versions.

These parameters, with their defaults, are as follows:
- `OCTANE_VERSION` : `2.8.2`
- `ROADRUNNER_CLI_VERSION` : `v2.7.1`
- `FRANKENPHP_VERSION` : `v1.4.4`
- `SWOOLE_VERSION` : `6.0.1`

I've currently only added the `OCTANE_VERSION` to the test workflow, as that's the most likely to need to change, but using the same pattern it's fairly trivial to add the other variables.
