### PR TITLE
Configure Composer to bypass security blocking

### DIFF
--- a/features/fixtures/laravel11/Dockerfile
+++ b/features/fixtures/laravel11/Dockerfile
@@ -18,6 +18,9 @@ COPY . .
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
 RUN cp .env.example .env
+# Allow composer to install packages that have security advisories, since
+# we're testing against older Laravel 11.x versions that are flagged
+ENV COMPOSER_NO_SECURITY_BLOCKING=1
 RUN composer install --no-dev
 RUN php artisan key:generate
 

--- a/features/fixtures/laravel11/Dockerfile-frankenphp
+++ b/features/fixtures/laravel11/Dockerfile-frankenphp
@@ -16,6 +16,10 @@ COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
 RUN cp .env.example .env
 RUN docker-php-ext-install sockets pcntl posix
+
+# Allow composer to install packages that have security advisories, since
+# we're testing against older Laravel 11.x versions that are flagged
+ENV COMPOSER_NO_SECURITY_BLOCKING=1
 RUN composer install --no-dev
 
 ARG OCTANE_VERSION

--- a/features/fixtures/laravel11/Dockerfile-roadrunner
+++ b/features/fixtures/laravel11/Dockerfile-roadrunner
@@ -19,6 +19,10 @@ COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
 RUN cp .env.example .env
 RUN docker-php-ext-install sockets pcntl posix
+
+# Allow composer to install packages that have security advisories, since
+# we're testing against older Laravel 11.x versions that are flagged
+ENV COMPOSER_NO_SECURITY_BLOCKING=1
 RUN composer install --no-dev
 
 ARG OCTANE_VERSION

--- a/features/fixtures/laravel11/Dockerfile-swoole
+++ b/features/fixtures/laravel11/Dockerfile-swoole
@@ -16,6 +16,10 @@ COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
 RUN cp .env.example .env
 RUN docker-php-ext-install sockets pcntl posix
+
+# Allow composer to install packages that have security advisories, since
+# we're testing against older Laravel 11.x versions that are flagged
+ENV COMPOSER_NO_SECURITY_BLOCKING=1
 RUN composer install --no-dev
 
 ARG OCTANE_VERSION


### PR DESCRIPTION
## Goal
Set COMPOSER_NO_SECURITY_BLOCKING to allow package installation despite security advisories for Laravel 11.x testing.

## Testing
Tested manually